### PR TITLE
56 revamp validation

### DIFF
--- a/build/launcher/stagerunner.go
+++ b/build/launcher/stagerunner.go
@@ -83,6 +83,7 @@ func handleTriggers(branch string, id int64, store storage.BuildStage, stage *pb
 			}
 		}
 		if !branchGood {
+			// todo: have a SKIPPED value? more descriptive
 			result := &pb.Result{Stage: stage.Name, Status: pb.StageResultVal_PASS, Error: "", Messages:[]string{fmt.Sprintf("skipping stage because %s is not in the trigger branches list", branch)}}
 			// we could save to db, the branch running is not in the list of trigger branches, so we can flip the shouldSkip bool now.
 			shouldSkip = true

--- a/build/validator_test.go
+++ b/build/validator_test.go
@@ -170,26 +170,27 @@ func TestOcelotValidator_ValidateConfig(t *testing.T) {
 
 }
 
-func TestOcelotValidator_ValidateWithBranch(t *testing.T) {
+func TestOcelotValidator_CheckQueueability(t *testing.T) {
 	buildConf := &pb.BuildConfig{
-		Image: "busybox:latest",
-		BuildTool: "w/e",
-		Branches: []string{"rc_.*"},
-		Stages: []*pb.Stage{
-			{Name: "hi", Script: []string{"echo sup"}},
-		},
+			Image: "busybox:latest",
+			BuildTool: "w/e",
+			Branches: []string{"rc_.*"},
+			Stages: []*pb.Stage{
+				{Name: "hi", Script: []string{"echo sup"}},
+			},
 	}
-	validator := GetOcelotValidator()
-	err := validator.ValidateWithBranch(buildConf, "rc_1234", nil)
+	validateor := GetOcelotValidator()
+	err := validateor.CheckQueueability(buildConf, "rc_1234")
 	if err != nil {
-		t.Error("validation should pass, error is : " + err.Error())
+		t.Error("should be queuable, error is: " + err.Error())
 	}
-	err = validator.ValidateWithBranch(buildConf, "r1_1234", nil)
+	err = validateor.CheckQueueability(buildConf, "r1_1234")
 	if err == nil {
-		t.Error("should not pass validation")
+		t.Error("should not be quueable, error is " + err.Error())
 	}
-	errMsg := "branch r1_1234 does not match any branches listed: [rc_.*]"
-	if err.Error() != errMsg {
-		t.Error(test.StrFormatErrors("err msg", errMsg, err.Error()))
+	if err != nil {
+		if _, ok := err.(*DoNotQueue); !ok {
+			t.Error("should be a do not queue error, instead the error is: " + err.Error())
+		}
 	}
 }

--- a/build_signaler/poll/changecheck.go
+++ b/build_signaler/poll/changecheck.go
@@ -14,7 +14,7 @@ import (
 func NewChangeChecker(signaler *signal.Signaler) *ChangeChecker {
 	return &ChangeChecker{
 		Signaler:signaler,
-		teller: &signal.BBWerkerTeller{},
+		teller: &signal.VcsWerkerTeller{},
 	}
 }
 

--- a/build_signaler/poll/changecheck.go
+++ b/build_signaler/poll/changecheck.go
@@ -58,9 +58,9 @@ func (w *ChangeChecker) HandleAllBranches(branchLastHashes map[string]string) er
 	for _, branchHist := range branchHistories {
 		lastHash, ok := branchLastHashes[branchHist.Branch]
 		if ok {
-			ocelog.Log().Info("this branch is already being tracked, checking if the built hash is the same as the one retrieved from VCS ")
+			ocelog.Log().WithField("branch", branchHist.Branch).Info("this branch is already being tracked, checking if the built hash is the same as the one retrieved from VCS ")
 			if lastHash != branchHist.Hash {
-				ocelog.Log().Info("hashes are not the same, telling werker...")
+				ocelog.Log().WithField("branch", branchHist.Branch).Info("hashes are not the same, telling werker...")
 				err = w.teller.TellWerker(branchHist.Hash, w.Signaler, branchHist.Branch, w.handler, w.token)
 				branchLastHashes[branchHist.Branch] = branchHist.Hash
 				if err != nil {
@@ -68,23 +68,24 @@ func (w *ChangeChecker) HandleAllBranches(branchLastHashes map[string]string) er
 				}
 			}
 		} else {
-			ocelog.Log().Info("branch was not previously tracked by ocelot, checking if its worthy of build")
+			ocelog.Log().WithField("branch", branchHist.Branch).Info("branch was not previously tracked by ocelot, checking if its worthy of build")
 			// add to map so we can track this branch
 			branchLastHashes[branchHist.Branch] = branchHist.Hash
 			// this has never been built/tracked before... so if anything has been committed in the last week, build it and add it to the map
 			lastCommitTime := time.Unix(branchHist.LastCommitTime.Seconds, int64(branchHist.LastCommitTime.Nanos))
 			lastWeek := time.Now().AddDate(0,0,-7)
-			if lastWeek.After(lastCommitTime) {
-				ocelog.Log().Info("it is! it has been active at least in the past week, it will be built then added to ocelot tracking")
+			ocelog.Log().WithField("last commit time", lastCommitTime.Format("Jan 2 15:04:05 2006")).WithField("last week", lastWeek.Format("Jan 2 15:04:05 2006")).Info("times!")
+			if lastCommitTime.After(lastWeek) {
+				ocelog.Log().WithField("branch", branchHist.Branch).WithField("hash", branchHist.Hash).Info("it is! it has been active at least in the past week, it will be built then added to ocelot tracking")
 				if err = w.teller.TellWerker(branchHist.Hash, w.Signaler, branchHist.Branch, w.handler, w.token); err != nil {
 					return err
 				}
 			} else {
-				ocelog.Log().Info("it is not! adding branch to tracking list, but not telling werker")
+				ocelog.Log().WithField("branch", branchHist.Branch).Info("it is not! adding branch to tracking list, but not telling werker")
 			}
 		}
 	}
-	ocelog.Log().Info("finished checking all branches")
+	ocelog.Log().WithField("acctrepo", w.AcctRepo).Info("finished checking all branches")
 	return nil
 }
 

--- a/build_signaler/poll/changecheck_test.go
+++ b/build_signaler/poll/changecheck_test.go
@@ -105,7 +105,7 @@ var allBranchesTests = []struct{
 	},
 	{
 		"untracked branch",
-		[]*pb.BranchHistory{{Hash:"1234", Branch:"abranch", LastCommitTime: &timestamp.Timestamp{Seconds:time.Now().Unix(), Nanos:0}},{Hash:"1a34", Branch:"bbranch", LastCommitTime: &timestamp.Timestamp{Seconds:time.Now().Add(-time.Hour*500).Unix(), Nanos:0}},},
+		[]*pb.BranchHistory{{Hash:"1234", Branch:"abranch", LastCommitTime: &timestamp.Timestamp{Seconds:time.Now().Unix(), Nanos:0}},{Hash:"1a34", Branch:"bbranch", LastCommitTime: &timestamp.Timestamp{Seconds:time.Now().AddDate(0,0,6).Unix(), Nanos:0}},},
 		map[string]string{"abranch":"1234"},
 		map[string]string{"abranch":"1234", "bbranch": "1a34"},
 		1,

--- a/build_signaler/werkerteller.go
+++ b/build_signaler/werkerteller.go
@@ -44,6 +44,9 @@ func (w *BBWerkerTeller) TellWerker(hash string, conf *Signaler, branch string, 
 		return errors.New("unable to get build configuration; err: " + err.Error())
 	}
 	if err = QueueAndStore(hash, branch, conf.AcctRepo, token, conf.RC, buildConf, conf.OcyValidator, conf.Producer, conf.Store); err != nil {
+		if _, ok := err.(*build.DoNotQueue); ok {
+			return errors.New("did not queue because it shouldn't be queued. explanation: " + err.Error())
+		}
 		return errors.New("unable to queue or store; err: " + err.Error())
 	}
 	return nil

--- a/build_signaler/werkerteller.go
+++ b/build_signaler/werkerteller.go
@@ -28,9 +28,9 @@ type WerkerTeller interface {
 	TellWerker(lastCommit string, conf *Signaler, branch string, handler models.VCSHandler, token string) (err error)
 }
 
-type BBWerkerTeller struct{}
+type VcsWerkerTeller struct{}
 
-func (w *BBWerkerTeller) TellWerker(hash string, conf *Signaler, branch string, handler models.VCSHandler, token string) (err error) {
+func (w *VcsWerkerTeller) TellWerker(hash string, conf *Signaler, branch string, handler models.VCSHandler, token string) (err error) {
 	ocelog.Log().WithField("hash", hash).WithField("acctRepo", conf.AcctRepo).WithField("branch", branch).Info("found new commit")
 	if token == "" {
 		return errors.New("token cannot be empty")

--- a/client/validate/validate.go
+++ b/client/validate/validate.go
@@ -144,20 +144,17 @@ Usage: ocelot validate /home/mariannef/git/MyProject/ocelot.yml
   If the file location is omitted, the client will attempt to find an ocelot.yml in the current directory and validate that. 
     Example:
       $ pwd
-	  /home/mariannef/git/MyProject
+        /home/mariannef/git/MyProject
       $ ocelot validate
-		BuildTool is specified ✓
-		Connecting to docker to check for image validity...
-		maven:3.5.3 exists ✓
-		/home/mariannef/git/MyProject/ocelot.yml is valid
+        BuildTool is specified ✓
+        Connecting to docker to check for image validity...
+        maven:3.5.3 exists ✓
+        /home/mariannef/git/MyProject/ocelot.yml is valid
   If you pass the -branch flag, then you can test to see if the given branch would result in a build
     Example:
       $ ocelot validate -branch testing ocelot.yml
-		Detected an IP address for the admin server host, therefore ocelot will not create https config.
-		If you really wish to try using an https config, then set USE_TLS=true as an environment variable.
-		Set NO_USE_TLS=true as an environment variable to suppress this warning in the future.
-		BuildTool is specified ✓
-		Connecting to docker to check for image validity...
-		maven:3.5.3 exists ✓
-		This branch would not build, the validation error was: branch testing not in the acceptable branches list: master, release\/.*
+        BuildTool is specified ✓
+        Connecting to docker to check for image validity...
+        maven:3.5.3 exists ✓
+        This branch would not build, the validation error was: branch testing not in the acceptable branches list: master, release\/.*
 `

--- a/client/validate/validate.go
+++ b/client/validate/validate.go
@@ -10,6 +10,8 @@ import (
 	"github.com/shankj3/ocelot/client/commandhelper"
 	models "github.com/shankj3/ocelot/models/pb"
 	"io/ioutil"
+	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -23,6 +25,7 @@ type cmd struct {
 	UI            cli.Ui
 	flags         *flag.FlagSet
 	ocelotFileLoc string
+	branch        string
 	config        *commandhelper.ClientConfig
 }
 
@@ -40,24 +43,25 @@ func (c *cmd) GetConfig() *commandhelper.ClientConfig {
 
 func (c *cmd) init() {
 	c.flags = flag.NewFlagSet("", flag.ContinueOnError)
-	c.flags.StringVar(&c.ocelotFileLoc, "file-loc", "ERROR", "*REQUIRED* location of your ocelot.yml file")
+	c.flags.StringVar(&c.ocelotFileLoc, "file-loc", "DEP", "*DEPRECATED! now -file-loc is not necessary* location of your ocelot.yml file")
+	c.flags.StringVar(&c.branch, "branch", "", "branch to validate ocelot.yml against. if this is passed, then the validator will also check to see if this matches the buildable branches list in the ocelot file. OPTIONAL")
 }
 
-func (c *cmd) validateOcelotYaml(ctx context.Context) int {
+func (c *cmd) validateOcelotYaml(ctx context.Context, ocelotFile string) int {
 	conf := &models.BuildConfig{}
 	dese := deserialize.New()
-	confFile, err := ioutil.ReadFile(c.ocelotFileLoc)
+	confFile, err := ioutil.ReadFile(ocelotFile)
 	if err != nil {
-		c.UI.Error(fmt.Sprintf("Could not read file at %s\nError: %s", c.ocelotFileLoc, err.Error()))
+		c.UI.Error(fmt.Sprintf("Could not read file at %s\nError: %s", ocelotFile, err.Error()))
 		return 1
 	}
 
 	if err = dese.YAMLToStruct(confFile, conf); err != nil {
-		c.UI.Error(fmt.Sprintf("Could not process file, please check make sure the file at %s exists\nError: %s", c.ocelotFileLoc, err.Error()))
+		c.UI.Error(fmt.Sprintf("Could not process file, please check make sure the file at %s exists\nError: %s", ocelotFile, err.Error()))
 		return 1
 	}
 
-	fileName := c.ocelotFileLoc[strings.LastIndex(c.ocelotFileLoc, "/")+1:]
+	fileName := ocelotFile[strings.LastIndex(ocelotFile, string(filepath.Separator))+1:]
 	if fileName != "ocelot.yml" {
 		c.UI.Error("Your file must be named ocelot.yml")
 		return 1
@@ -69,8 +73,15 @@ func (c *cmd) validateOcelotYaml(ctx context.Context) int {
 		c.UI.Error(fmt.Sprintf("Invalid ocelot.yml file: %s", err.Error()))
 		return 1
 	}
+	if c.branch != "" {
+		err := fileValidator.CheckQueueability(conf, c.branch)
+		if err != nil {
+			c.UI.Error("This branch would not build, the validation error was: " + err.Error())
+			return 1
+		}
+	}
 
-	c.UI.Info(fmt.Sprintf("%s is valid", c.ocelotFileLoc))
+	c.UI.Info(fmt.Sprintf("%s is valid", ocelotFile))
 	return 0
 }
 
@@ -78,14 +89,42 @@ func (c *cmd) Run(args []string) int {
 	if err := c.flags.Parse(args); err != nil {
 		return 1
 	}
+	ocelotFile := ""
 
-	if c.ocelotFileLoc == "ERROR" {
-		c.UI.Error("flag --file-loc is required and must be a local path to an ocelot.yml file")
+	// Check for arg validation
+	args = c.flags.Args()
+	switch len(args) {
+	case 0:
+	case 1:
+		ocelotFile = args[0]
+	default:
+		c.UI.Error(fmt.Sprintf("Too many arguments (expected 1, got %d)", len(args)))
 		return 1
+	}
+	// if ocelot not passed the new way, just on the command line without a flag,
+	// first check if the flag was passed...
+	if c.ocelotFileLoc != "DEP" {
+		ocelotFile = c.ocelotFileLoc
+	}
+	// then check the current directory for an ocelot.yml file...
+	// if neither of these works, then give up
+	if ocelotFile == "" {
+		dir, err := os.Getwd()
+		if err != nil {
+			c.UI.Error("Unable to get the current working directory, so not able to detect ocelot.yml file in current location. Please pass as an argument.")
+			return 1
+		}
+		_, err = os.Stat(filepath.Join(dir, "ocelot.yml"))
+		if err == nil {
+			ocelotFile = filepath.Join(dir, "ocelot.yml")
+		} else {
+			c.UI.Error("Could not find ocelot.yml in current directory. Please pass ocelot.yml location as an argument.")
+			return 1
+		}
 	}
 
 	ctx := context.Background()
-	return c.validateOcelotYaml(ctx)
+	return c.validateOcelotYaml(ctx, ocelotFile)
 }
 
 func (c *cmd) Synopsis() string {
@@ -98,8 +137,27 @@ func (c *cmd) Help() string {
 
 const helpcmdSynopsis = "built-in validator"
 const helpcmdHelp = `
-Usage: ocelot validate -file-loc <full_path_to_your_ocelot_file>
+Usage: ocelot validate /home/mariannef/git/MyProject/ocelot.yml
   Interacting with ocelot validator
-  This client takes in an argument as a path to a local ocelot.yaml file
-  Example: ocelot validate -file-loc /home/mariannef/git/MyProject/ocelot.yml
+  This client takes a positional argument of the ocelot.yml file, it must be last in the command entered:
+    Example: ocelot validate /home/mariannef/git/MyProject/ocelot.yml
+  If the file location is omitted, the client will attempt to find an ocelot.yml in the current directory and validate that. 
+    Example:
+      $ pwd
+	  /home/mariannef/git/MyProject
+      $ ocelot validate
+		BuildTool is specified ✓
+		Connecting to docker to check for image validity...
+		maven:3.5.3 exists ✓
+		/home/mariannef/git/MyProject/ocelot.yml is valid
+  If you pass the -branch flag, then you can test to see if the given branch would result in a build
+    Example:
+      $ ocelot validate -branch testing ocelot.yml
+		Detected an IP address for the admin server host, therefore ocelot will not create https config.
+		If you really wish to try using an https config, then set USE_TLS=true as an environment variable.
+		Set NO_USE_TLS=true as an environment variable to suppress this warning in the future.
+		BuildTool is specified ✓
+		Connecting to docker to check for image validity...
+		maven:3.5.3 exists ✓
+		This branch would not build, the validation error was: branch testing not in the acceptable branches list: master, release\/.*
 `

--- a/client/validate/validate_test.go
+++ b/client/validate/validate_test.go
@@ -4,9 +4,11 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/go-test/deep"
 	"github.com/mitchellh/cli"
 	"github.com/shankj3/ocelot/common/testutil"
 )
@@ -60,6 +62,7 @@ Error: yaml: unmarshal errors:
 	}
 }
 
+
 func TestCmd_RunPathFileName(t *testing.T) {
 	ui := cli.NewMockUi()
 	pwd, _ := os.Getwd()
@@ -103,5 +106,60 @@ func TestCmd_RunPathFileWrongFormat(t *testing.T) {
 	if strings.Compare(expectedError, errMsg) != 0 {
 		t.Errorf("output and expected not the same,  \n"+
 			"expected:\n%s\ngot:\n%s", expectedError, errMsg)
+	}
+}
+
+func TestCmd_Run_nofilepathloc(t *testing.T) {
+	ui := cli.NewMockUi()
+	//pwd, _ := os.Getwd()
+	cmdd := New(ui)
+	var args = []string{"test-fixtures/valid/ocelot.yml"}
+	if exit := cmdd.Run(args); exit != 0 {
+		t.Log(string(ui.OutputWriter.Bytes()))
+		t.Log(string(ui.ErrorWriter.Bytes()))
+		t.Error("should exit with error code 0: ", exit)
+	}
+}
+
+func TestCmd_Run_validateWithBranch(t *testing.T) {
+	ui := cli.NewMockUi()
+	//pwd, _ := os.Getwd()
+	cmdd := New(ui)
+	var args = []string{"-branch=develop", "test-fixtures/valid/ocelot.yml"}
+	if exit := cmdd.Run(args); exit != 1 {
+		t.Error("should exit with error code 1: ", exit)
+	}
+	errr := string(ui.ErrorWriter.Bytes())
+	expectedErr := "This branch would not build, the validation error was: branch develop not in the acceptable branches list: master\n"
+	if diff := deep.Equal(expectedErr, errr); diff != nil {
+		t.Error(diff)
+	}
+}
+
+func TestCmd_Run_fromCurrentDirectory(t *testing.T) {
+	ui := cli.NewMockUi()
+	pwd, _ := os.Getwd()
+	defer os.Chdir(pwd)
+	cmdd := New(ui)
+	os.Chdir(filepath.Join("test-fixtures", "valid"))
+	var args []string
+	if exit := cmdd.Run(args); exit != 0 {
+		t.Error("should exit with 0: " , exit)
+	}
+	t.Log(string(ui.OutputWriter.Bytes()))
+	t.Log(string(ui.ErrorWriter.Bytes()))
+}
+
+func TestCmd_Run_fromCurrentDirectory_notFound(t *testing.T) {
+	ui := cli.NewMockUi()
+	cmdd := New(ui)
+	var args []string
+	if exit := cmdd.Run(args); exit != 1 {
+		t.Error("should exit with 1: " , exit)
+	}
+	errorStr := string(ui.ErrorWriter.Bytes())
+	expected := "Could not find ocelot.yml in current directory. Please pass ocelot.yml location as an argument.\n"
+	if diff := deep.Equal(expected, errorStr); diff != nil {
+		t.Errorf("unexpected error output: %#v", diff)
 	}
 }

--- a/router/admin/signaler_actions.go
+++ b/router/admin/signaler_actions.go
@@ -101,6 +101,7 @@ func (g *guideOcelotServer) BuildRepoAndHash(buildReq *pb.BuildReq, stream pb.Gu
 	}
 	stream.Send(RespWrap(fmt.Sprintf("Successfully retrieved ocelot.yml for %s %s", buildReq.AcctRepo, models.CHECKMARK)))
 	stream.Send(RespWrap(fmt.Sprintf("Storing build data for %s...", buildReq.AcctRepo)))
+	// todo: change this to use VcsWorkerTeller in build_signaler package
 	if err = signal.QueueAndStore(fullHash, branch, buildReq.AcctRepo, token, g.RemoteConfig, buildConf, g.OcyValidator, g.Producer, g.Storage); err != nil {
 		if _, ok := err.(*build.DoNotQueue); ok {
 			log.Log().Info("not queuing because i'm not supposed to, explanation: " + err.Error())

--- a/router/hookhandler/hookhandler.go
+++ b/router/hookhandler/hookhandler.go
@@ -26,14 +26,14 @@ type HookHandler interface {
 	SetValidator(validator *build.OcelotValidator)
 	GetStorage() storage.OcelotStorage
 	SetStorage(storage.OcelotStorage)
-	GetTeller() *signal.BBWerkerTeller
+	GetTeller() *signal.VcsWerkerTeller
 	GetSignaler() *signal.Signaler
 }
 
 //context contains long lived resources. See bottom for getters/setters
 type HookHandlerContext struct {
 	*signal.Signaler
-	teller *signal.BBWerkerTeller
+	teller *signal.VcsWerkerTeller
 }
 
 // On receive of repo push, marshal the json to an object then build the appropriate pipeline config and put on NSQ queue.
@@ -122,11 +122,11 @@ func (hhc *HookHandlerContext) GetStorage() storage.OcelotStorage {
 	return hhc.Store
 }
 
-func (hhc *HookHandlerContext) GetTeller() *signal.BBWerkerTeller {
+func (hhc *HookHandlerContext) GetTeller() *signal.VcsWerkerTeller {
 	return hhc.teller
 }
 
-func (hhc *HookHandlerContext) SetTeller(tell *signal.BBWerkerTeller) {
+func (hhc *HookHandlerContext) SetTeller(tell *signal.VcsWerkerTeller) {
 	hhc.teller = tell
 }
 


### PR DESCRIPTION
CLOSES #56 

- Updated the `ocelot validate` 
    -  takes in a `-branch` parameter so you can see if your config will result in a build with one of your branches 
    - deprecated `-file-loc` in favor of positional arguments
- Updated `QueueAndStore` to check to see if the branch associated with this pre-build is even in the branches list in the `ocelot.yml` file. If it isn't, it shouldn't be stored anywhere because we don't care. Before, it was storing all branches if all branches were being polled, even though most of the branches didn't result in a build. Lots of unnecessary failures. 