### PR TITLE
K8s multiple integration creds support

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,10 +2,16 @@
 
 
 [[projects]]
+  name = "cloud.google.com/go"
+  packages = ["civil"]
+  revision = "0fd7230b2a7505833d5f69b75cbd6c9582401479"
+  version = "v0.23.0"
+
+[[projects]]
   name = "github.com/Jeffail/gabs"
   packages = ["."]
-  revision = "2a3aa15961d5fee6047b8151b67ac2f08ba2c48c"
-  version = "1.0"
+  revision = "7a0fed31069aba77993a518cc2f37b28ee7aa883"
+  version = "1.1"
 
 [[projects]]
   name = "github.com/Microsoft/go-winio"
@@ -61,7 +67,7 @@
     ".",
     "internal/cp"
   ]
-  revision = "b594cb31ff9cf2d061450ef0e1cc1f33fd211a5a"
+  revision = "c12642a8f7884ab01719704032c36ff300ff52c6"
 
 [[projects]]
   name = "github.com/docker/distribution"
@@ -107,14 +113,14 @@
 [[projects]]
   name = "github.com/docker/go-units"
   packages = ["."]
-  revision = "0dadbb0345b35ec7ef35e228dabb8de89a65bf52"
-  version = "v0.3.2"
+  revision = "47565b4f722fb6ceae66b95f853feed578a4a51c"
+  version = "v0.3.3"
 
 [[projects]]
   name = "github.com/fatih/color"
   packages = ["."]
-  revision = "507f6050b8568533fb3f5504de8e5205fa62a114"
-  version = "v1.6.0"
+  revision = "5b77d2a35fb0ede96d138fc9a99f5c9b6aef11b4"
+  version = "v1.7.0"
 
 [[projects]]
   name = "github.com/fatih/structs"
@@ -131,8 +137,8 @@
 [[projects]]
   name = "github.com/go-sql-driver/mysql"
   packages = ["."]
-  revision = "a0583e0143b1624142adab07e0e97fe106d99561"
-  version = "v1.3"
+  revision = "d523deb1b23d913de5bdada721a6071e71283618"
+  version = "v1.4.0"
 
 [[projects]]
   name = "github.com/go-test/deep"
@@ -149,7 +155,7 @@
     "internal/murmur",
     "internal/streams"
   ]
-  revision = "12e3a8c05db483441932e84ab6c35c339fb01de7"
+  revision = "651d6b1f343c6e168e45d119dcfe8f71e5bafb32"
 
 [[projects]]
   name = "github.com/gogo/protobuf"
@@ -179,7 +185,7 @@
   branch = "master"
   name = "github.com/golang/snappy"
   packages = ["."]
-  revision = "553a641470496b2327abcac10b36396bd98e45c9"
+  revision = "2e65f85255dbc3072edf28d6b5b8efc472979f5a"
 
 [[projects]]
   name = "github.com/google/uuid"
@@ -196,14 +202,14 @@
 [[projects]]
   name = "github.com/gorilla/context"
   packages = ["."]
-  revision = "1ea25387ff6f684839d82767c1733ff4d4d15d0a"
-  version = "v1.1"
+  revision = "08b5f424b9271eedf6f9f0ce86cb9396ed337a42"
+  version = "v1.1.1"
 
 [[projects]]
   name = "github.com/gorilla/mux"
   packages = ["."]
-  revision = "53c1911da2b537f792e7cafcb446b05ffe33b996"
-  version = "v1.6.1"
+  revision = "e3702bed27f0d39777b0b37b664b6280e8ef8fbf"
+  version = "v1.6.2"
 
 [[projects]]
   name = "github.com/gorilla/websocket"
@@ -219,8 +225,8 @@
     "runtime/internal",
     "utilities"
   ]
-  revision = "07f5e79768022f9a3265235f0db4ac8c3f675fec"
-  version = "v1.3.1"
+  revision = "92583770e3f01b09a0d3e9bdf64321d8bebd48f2"
+  version = "v1.4.1"
 
 [[projects]]
   branch = "master"
@@ -237,8 +243,8 @@
     "testutil",
     "testutil/retry"
   ]
-  revision = "9a494b5fb9c86180a5702e29c485df1507a47198"
-  version = "v1.0.6"
+  revision = "5174058f0d2bda63fa5198ab96c33d9a909c58ed"
+  version = "v1.1.0"
 
 [[projects]]
   branch = "master"
@@ -256,7 +262,7 @@
   branch = "master"
   name = "github.com/hashicorp/go-hclog"
   packages = ["."]
-  revision = "5bcb0f17e36442247290887cc914a6e507afa5c4"
+  revision = "69ff559dc25f3b435631604f573a5fa1efdb6433"
 
 [[projects]]
   branch = "master"
@@ -280,7 +286,7 @@
   branch = "master"
   name = "github.com/hashicorp/go-plugin"
   packages = ["."]
-  revision = "8068b0bdcfb702b4ab69d0e42c6023b4996c3026"
+  revision = "e8d22c780116115ae5624720c9af0c97afe4f551"
 
 [[projects]]
   branch = "master"
@@ -323,7 +329,7 @@
     "json/scanner",
     "json/token"
   ]
-  revision = "f40e974e75af4e271d97ce0fc917af5898ae7bda"
+  revision = "ef8a98b0bbce4a65b5aa4c368430a80ddc533168"
 
 [[projects]]
   name = "github.com/hashicorp/serf"
@@ -386,7 +392,7 @@
   branch = "master"
   name = "github.com/hashicorp/yamux"
   packages = ["."]
-  revision = "2658be15c5f05e76244154714161f17e3e77de2e"
+  revision = "3520598351bb3500a49ae9563f5539666ae0a27c"
 
 [[projects]]
   branch = "master"
@@ -412,7 +418,7 @@
     "openpgp/s2k",
     "rsa"
   ]
-  revision = "c86609b27f9eaa80962974009eb5472d58bb4043"
+  revision = "d11a37f123888ff060339f516e392032dfcb98ff"
 
 [[projects]]
   branch = "master"
@@ -421,7 +427,7 @@
     ".",
     "oid"
   ]
-  revision = "d34b9ff171c21ad295489235aec8b6626023cd04"
+  revision = "90697d60dd844d5ef6ff15135d0203f65d2f53b8"
 
 [[projects]]
   name = "github.com/mattn/go-colorable"
@@ -457,7 +463,7 @@
   branch = "master"
   name = "github.com/mitchellh/cli"
   packages = ["."]
-  revision = "b068abc08c994321eafd9fd500d0704cb6defcb1"
+  revision = "c48282d14eba4b0817ddef3f832ff8d13851aefd"
 
 [[projects]]
   branch = "master"
@@ -469,7 +475,7 @@
   branch = "master"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
-  revision = "b8bc1bf767474819792c23f32d8286a45736f1c6"
+  revision = "3864e76763d94a6df2f9960b16a20a33da9f9a66"
 
 [[projects]]
   branch = "master"
@@ -481,7 +487,7 @@
   branch = "master"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
-  revision = "00c29f56e2386353d58c599509e8dc3801b0d716"
+  revision = "bb74f1db0675b241733089d5a1faa5dd8b0ef57b"
 
 [[projects]]
   branch = "master"
@@ -517,7 +523,7 @@
   branch = "master"
   name = "github.com/olekukonko/tablewriter"
   packages = ["."]
-  revision = "b8a9be070da40449e501c3c4730a889e42d87a9e"
+  revision = "d4647c9c7a84d847478d890b816b7d8b62b0b279"
 
 [[projects]]
   name = "github.com/patrickmn/go-cache"
@@ -555,10 +561,10 @@
   version = "v0.1"
 
 [[projects]]
-  branch = "master"
   name = "github.com/sethgrid/pester"
   packages = ["."]
-  revision = "ed9870dad3170c0b25ab9b11830cc57c3a7798fb"
+  revision = "03e26c9abbbf5accb8349790bf9f41bde09d72c3"
+  version = "1.0.0"
 
 [[projects]]
   name = "github.com/shankj3/go-til"
@@ -604,7 +610,7 @@
     "ssh",
     "ssh/terminal"
   ]
-  revision = "88942b9c40a4c9d203b82b3731787b672d6e809b"
+  revision = "b47b1587369238182299fe4dad77d05b8b461e06"
 
 [[projects]]
   branch = "master"
@@ -612,15 +618,16 @@
   packages = [
     "context",
     "context/ctxhttp",
+    "http/httpguts",
     "http2",
     "http2/hpack",
     "idna",
+    "internal/socks",
     "internal/timeseries",
-    "lex/httplex",
     "proxy",
     "trace"
   ]
-  revision = "6078986fec03a1dcc236c34816c71b0e05018fda"
+  revision = "1e491301e022f8f977054da4c2d852decd59571f"
 
 [[projects]]
   branch = "master"
@@ -630,7 +637,7 @@
     "clientcredentials",
     "internal"
   ]
-  revision = "fdc9e635145ae97e6c2cb777c48305600cf515cb"
+  revision = "1e0a3fa8ba9a5c9eb35c271780101fdaf1b205d7"
 
 [[projects]]
   branch = "master"
@@ -639,7 +646,7 @@
     "unix",
     "windows"
   ]
-  revision = "13d03a9a82fba647c21a0ef8fba44a795d0f0835"
+  revision = "bc2ef10f1b658ea907736406814a6187b49ea3ec"
 
 [[projects]]
   name = "golang.org/x/text"
@@ -665,6 +672,7 @@
 [[projects]]
   name = "google.golang.org/appengine"
   packages = [
+    "cloudsql",
     "internal",
     "internal/base",
     "internal/datastore",
@@ -683,7 +691,7 @@
     "googleapis/api/annotations",
     "googleapis/rpc/status"
   ]
-  revision = "ab0870e398d5dd054b868c0db1481ab029b9a9f2"
+  revision = "81158efcc9f219c511e4d3c0d61a0e6e49c01a24"
 
 [[projects]]
   name = "google.golang.org/grpc"
@@ -738,8 +746,8 @@
 [[projects]]
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "86f5ed62f8a0ee96bd888d2efdfd6d4fb100a4eb"
-  version = "v2.2.0"
+  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
+  version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/build/integrations/kubeconf/k8s.go
+++ b/build/integrations/kubeconf/k8s.go
@@ -1,11 +1,13 @@
 package kubeconf
 
 import (
-	"errors"
-
+	"fmt"
+	"bytes"
+	"encoding/json"
 	"github.com/shankj3/ocelot/build/integrations"
 	"github.com/shankj3/ocelot/common"
 	"github.com/shankj3/ocelot/models/pb"
+	ocelog "github.com/shankj3/go-til/log"
 )
 
 func Create() integrations.StringIntegrator {
@@ -24,24 +26,57 @@ func (k *K8sInt) SubType() pb.SubCredType {
 	return pb.SubCredType_KUBECONF
 }
 
+// Create a config file for every k8s entry, named ("~/.kube/%s", k.identifier)
 func (k *K8sInt) MakeBashable(encoded string) []string {
-	return []string{"/bin/sh", "-c", "mkdir -p ~/.kube && echo \"${KCONF}\" | base64 -d > ~/.kube/config"}
+	//return []string{"/bin/bash", "-c", "mkdir -p ~/.kube && for i in ${K8S_INDEX}; do echo \"${!i}\" > ~/.kube/${i}; done && echo Printing file ~/.kube/${i} && cat ~/.kube/${i}"}
+	return []string{"/bin/bash", "-c", "mkdir -p ~/.kube && for kubeconf in ${K8S_INDEX}; do echo \"${!kubeconf}\" > ~/.kube/${kubeconf}; done"}
 }
 
+// TODO: This integration is only relevant if we call kubectl or helm in any step
 func (k *K8sInt) IsRelevant(wc *pb.BuildConfig) bool {
 	return true
 }
 
+// FIXME: The StringIntegrator interface should be refactored to support multiple instances
+// FIXME: For backwards compatibility, check if key is THERECANONLYBEONE, and use the name "config"
 func (k *K8sInt) GenerateIntegrationString(creds []pb.OcyCredder) (string, error) {
-	kubeCred, ok := creds[0].(*pb.K8SCreds)
-	if !ok {
-		return "", errors.New("could not cast to k8s cred")
+  // Stuff creds into a map, and convert into json so we can pass it with some context for environment variables
+	multiCreds := make(map[string]string)
+  for _, cluster := range creds {
+		multiCreds[cluster.GetIdentifier()] = cluster.GetClientSecret()
 	}
-	configEncoded := common.StrToBase64(kubeCred.K8SContents)
+	multiCredsJson, _ := json.Marshal(multiCreds)
+
+	configEncoded := common.StrToBase64(string(multiCredsJson))
 	k.k8sContents = configEncoded
 	return configEncoded, nil
 }
 
+// Deserialize k.k8sContents, and build multiple environment varialbes
 func (k *K8sInt) GetEnv() []string {
-	return []string{"KCONF=" + k.k8sContents}
+	conf_json, _ := common.Base64ToBitz(k.k8sContents)
+	configs := make(map[string]string)
+	json.Unmarshal([]byte(string(conf_json)), &configs)
+
+  env_vars := make([]string, len(configs)+1)
+	index := 0
+
+	var cluster_list bytes.Buffer
+	for cluster, conf := range configs {
+		var buffer bytes.Buffer
+		// FIXME: For backwards compatibility. Remove after allowing existing builds to migrate to new functionality
+		if cluster == "THERECANONLYBEONE" {
+			buffer.WriteString(fmt.Sprintf("%s=%s", "config", conf))
+			cluster_list.WriteString(fmt.Sprintf("%s ", "config"))
+		} else {
+			buffer.WriteString(fmt.Sprintf("%s=%s", cluster, conf))
+			cluster_list.WriteString(fmt.Sprintf("%s ", cluster))
+		}
+		env_vars[index] = buffer.String()
+		index++
+	}
+
+  // We will use K8S_INDEX to reference the kubeconfig environment vars in a bash loop
+	env_vars[index] = fmt.Sprintf("%s=%s", "K8S_INDEX", cluster_list.String())
+	return env_vars
 }

--- a/build/launcher/preflightintegrate.go
+++ b/build/launcher/preflightintegrate.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/shankj3/go-til/log"
+	ocelog "github.com/shankj3/go-til/log"
 	"github.com/shankj3/ocelot/build"
 	"github.com/shankj3/ocelot/build/integrations"
 	"github.com/shankj3/ocelot/build/integrations/dockerconfig"
@@ -81,6 +81,7 @@ func (w *launcher) doIntegrations(ctx context.Context, werk *pb.WerkerTask, bldr
 	return
 }
 
+// TODO: This should handle more than just kubectl. Helm, for example.
 func (w *launcher) downloadBinaries(ctx context.Context, su *build.StageUtil, bldr build.Builder) (result *pb.Result, duration time.Duration, start time.Time) {
 	start = time.Now()
 	defer func(){duration = time.Now().Sub(start)}()
@@ -101,7 +102,7 @@ func (w *launcher) downloadBinaries(ctx context.Context, su *build.StageUtil, bl
 func handleIntegrationErr(err error, integrationName string, stage *build.StageUtil, msgs []string) *pb.Result {
 	_, ok := err.(*common.NoCreds)
 	if !ok {
-		log.IncludeErrField(err).Error("returning failed setup because repo integration failed for: ", integrationName)
+		ocelog.IncludeErrField(err).Error("returning failed setup because repo integration failed for: ", integrationName)
 		return &pb.Result{
 			Stage: stage.GetStage(),
 			Status: pb.StageResultVal_FAIL,

--- a/client/creds/k8s/add/add.go
+++ b/client/creds/k8s/add/add.go
@@ -22,6 +22,7 @@ type cmd struct {
 	flags   *flag.FlagSet
 	fileloc string
 	account string
+	name 		string
 	config  *commandhelper.ClientConfig
 }
 
@@ -43,7 +44,9 @@ func (c *cmd) init() {
 	c.flags.StringVar(&c.fileloc, "kubeconfig", "ERROR",
 		"Location of kubeconfig file to upload")
 	c.flags.StringVar(&c.account, "acct", "ERROR",
-		"Account name to file kubeconfig under.")
+		"Account name to file kubeconfig under")
+	c.flags.StringVar(&c.name, "name", "ERROR",
+		"Name for kubeconfig")
 }
 
 // uploadCredential will check if credential already exists. if it does, it will ask if the user wishes to overwrite. if the user responds YES, the credential will be updated.
@@ -55,8 +58,8 @@ func uploadCredential(ctx context.Context, client models.GuideOcelotClient, UI c
 	}
 
 	if exists.Exists {
-		update, err := UI.Ask(fmt.Sprintf("Entry with Account Name %s and Repo Type %s already exists. Do you want to overwrite? "+
-			"Only a YES will continue with update, otherwise the client will exit. ", cred.AcctName, strings.ToLower(cred.SubType.String())))
+		update, err := UI.Ask(fmt.Sprintf("Account Name %s already has a Repo Type %s config with the name %s. Do you want to overwrite? "+
+			"Only a YES will continue with update, otherwise the client will exit. ", cred.AcctName, strings.ToLower(cred.SubType.String()), cred.Identifier))
 		if err != nil {
 			return err
 		}
@@ -93,14 +96,17 @@ func (c *cmd) Run(args []string) int {
 		c.UI.Error("-kubeconfig required")
 		return 1
 	}
+	k8cred.Identifier = c.name
+	if c.name == "ERROR" {
+		c.UI.Error("-name required")
+		return 1
+	}
 	kubeconf, err := ioutil.ReadFile(c.fileloc)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Could not read file at %s \nError: %s", c.fileloc, err.Error()))
 		return 1
 	}
 	k8cred.K8SContents = string(kubeconf)
-	// right now, only support one kubeconfig per account
-	k8cred.Identifier = "THERECANONLYBEONE"
 
 	if err = uploadCredential(ctx, c.config.Client, c.UI, k8cred); err != nil {
 		if _, ok := err.(*commandhelper.DontOverwrite); ok {
@@ -124,6 +130,6 @@ func (c *cmd) Help() string {
 
 const synopsis = "Add a kubeconfig for connection with kubernetes to ocelot"
 const help = `
-Usage: ocelot creds k8s add -acct my_kewl_acct -kubeconfig=/home/user/kubeconfig.yaml
+Usage: ocelot creds k8s add -acct my_kewl_acct -name cluster_name -kubeconfig=/home/user/.kube/cluster-config.yaml
 
 `

--- a/client/creds/k8s/add/add.go
+++ b/client/creds/k8s/add/add.go
@@ -22,7 +22,7 @@ type cmd struct {
 	flags   *flag.FlagSet
 	fileloc string
 	account string
-	name 		string
+	name    string
 	config  *commandhelper.ClientConfig
 }
 

--- a/client/creds/k8s/add/add.go
+++ b/client/creds/k8s/add/add.go
@@ -46,7 +46,7 @@ func (c *cmd) init() {
 	c.flags.StringVar(&c.account, "acct", "ERROR",
 		"Account name to file kubeconfig under")
 	c.flags.StringVar(&c.name, "name", "ERROR",
-		"Name for kubeconfig")
+		"Name for kubeconfig (Using your cluster name is recommended)")
 }
 
 // uploadCredential will check if credential already exists. if it does, it will ask if the user wishes to overwrite. if the user responds YES, the credential will be updated.

--- a/client/creds/k8s/list/list.go
+++ b/client/creds/k8s/list/list.go
@@ -86,9 +86,10 @@ func NoDataHeader(ui cli.Ui) {
 }
 
 func Prettify(cred *models.K8SCreds) string {
-	str := `AcctName: %s
+	str := `Account: %s
+ConfigName: %s
 `
-	return fmt.Sprintf(str, cred.AcctName)
+	return fmt.Sprintf(str, cred.AcctName, cred.Identifier)
 }
 
 const synopsis = "List all credentials used for artifact repositories"

--- a/cmd/admin/Dockerfile
+++ b/cmd/admin/Dockerfile
@@ -7,6 +7,7 @@ COPY . .
 RUN cd cmd/${SERVICE_NAME} && CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /go/bin/${SERVICE_NAME} .
 
 FROM alpine:3.7
+RUN apk --update --no-cache add docker
 ENV SERVICE_NAME admin
 COPY models/pb/*.swagger.json /swagger/
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/

--- a/cmd/werker/Dockerfile
+++ b/cmd/werker/Dockerfile
@@ -2,11 +2,12 @@ FROM ocelot-build as builder
 
 ARG SERVICE_NAME=werker
 WORKDIR /go/src/github.com/shankj3/ocelot/
-COPY ../../old/werker .
+#COPY ../../old/werker .
 
 RUN cd cmd/${SERVICE_NAME} && CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /go/bin/${SERVICE_NAME} .
 
 FROM alpine:3.7
+RUN apk --update --no-cache add docker
 ENV SERVICE_NAME werker
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/bin/${SERVICE_NAME} /

--- a/cmd/werker/Dockerfile
+++ b/cmd/werker/Dockerfile
@@ -2,7 +2,7 @@ FROM ocelot-build as builder
 
 ARG SERVICE_NAME=werker
 WORKDIR /go/src/github.com/shankj3/ocelot/
-#COPY ../../old/werker .
+COPY . .
 
 RUN cd cmd/${SERVICE_NAME} && CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /go/bin/${SERVICE_NAME} .
 

--- a/deploy/infra/consul-docker-compose.yml
+++ b/deploy/infra/consul-docker-compose.yml
@@ -3,6 +3,7 @@ services:
   # Copied directly from ./docs/docker-compose/vault-consul/docker-compose.yml, with volume paths slightly modified, and with logging
   consul:
     image: consul:1.0.0
+    container_name: consul
     hostname: consul
     command: agent -dev -client 0.0.0.0
     ports:
@@ -14,3 +15,7 @@ services:
       options:
         max-size: "200k"
         max-file: "10"
+networks:
+  default:
+    external:
+      name: ocelot

--- a/deploy/infra/dockerized_dev_notes.txt
+++ b/deploy/infra/dockerized_dev_notes.txt
@@ -1,0 +1,20 @@
+If you're reading this, you want to run the ocelot infra with the docker-compose files. This process is not completely automated, but these are the minimal manual steps:
+
+TODO: The ocelot containers rely on docker for macOS specific dns functionality. Need to generalize this more
+
+* Create an external network named 'ocelot'
+* Start the following services: nsq (all of them), postgres, consul, vault (docker-compose -f <compose file> up -d)
+* Init and unseal vault, check in consul that everyone reports healthy
+* Then run the scripts/setup-cv.sh file -- Make sure your DB password is set correctly!
+
+* Go to the project root
+* Build the ocelot-builder image (make docker-base)
+* Build the docker containers (make docker-build)
+* Build and install the ocelot client (make local)
+* Start the ocelot cluster (docker-compose up -d)
+
+* Set your ADMIN_HOST=localhost, and ADMIN_PORT=10000 environment vars to point at your local ocelot instance
+
+You should be up and running. To get started, you should add creds for your vcs, and anything else you need to test with.
+
+When you start builds, you should see the docker containers started on your host docker-engine (since you mount the docker socket into all the ocelot containers)

--- a/deploy/infra/docs/docker-compose/vault-consul/config/vault/with-consul.hcl
+++ b/deploy/infra/docs/docker-compose/vault-consul/config/vault/with-consul.hcl
@@ -1,6 +1,6 @@
 backend "consul" {
-  address = "http://172.18.0.1:8500"
-  advertise_addr = "http://127.0.0.1:8200"
+  address = "http://consul:8500"
+  advertise_addr = "http://consul:8200"
   path = "vault"
   scheme = "http"
 }

--- a/deploy/infra/nsq-docker-compose.yml
+++ b/deploy/infra/nsq-docker-compose.yml
@@ -3,9 +3,9 @@ services:
   # Copied directly from ./util/nsqpb/docker-compose.yml, modified with logging
   nsqlookupd:
     image: nsqio/nsq
+    container_name: nsqlookupd
     command: >
       /nsqlookupd
-      -broadcast-address localhost:4160
     ports:
       - 4160:4160
       - 4161:4161
@@ -16,10 +16,12 @@ services:
         max-file: "10"
   nsqd:
     image: nsqio/nsq
+    container_name: nsqd
+    depends_on:
+      - nsqlookupd
     command: >
       /nsqd
-      -broadcast-address localhost
-      -lookupd-tcp-address nsqlookupd:4160
+      -lookupd-tcp-address docker.for.mac.host.internal:4160
     ports:
       - 4150:4150
       - 4151:4151
@@ -28,15 +30,22 @@ services:
       options:
         max-size: "200k"
         max-file: "10"
-#  nsqadmin:
-#    image: nsqio/nsq
-#    command: >
-#      /nsqadmin
-#      -nsqd-http-address nsqd:4151
-#    ports:
-#      - 4171:4171
-#    logging:
-#      driver: "json-file"
-#      options:
-#        max-size: "200k"
-#        max-file: "10"
+  nsqadmin:
+    image: nsqio/nsq
+    container_name: nsqadmin
+    depends_on:
+      - nsqlookupd
+    command: >
+      /nsqadmin
+      -lookupd-http-address docker.for.mac.host.internal:4161
+    ports:
+      - 4171:4171
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "200k"
+        max-file: "10"
+networks:
+  default:
+    external:
+      name: ocelot

--- a/deploy/infra/postgres-docker-compose.yml
+++ b/deploy/infra/postgres-docker-compose.yml
@@ -2,8 +2,13 @@ version: "3.3"
 services:
   db:
     image: postgres
+    container_name: db
     hostname: db
-#    volumes:
-#    - ./util/storage/test-fixtures/schema.sql:/docker-entrypoint-initdb.d/schema.sql
+    volumes:
+    - ../../docs/postgres/ocelot_postgres_schema.sql:/docker-entrypoint-initdb.d/schema.sql
     ports:
       - 5432:5432
+networks:
+  default:
+    external:
+      name: ocelot

--- a/deploy/infra/vault-docker-compose.yml
+++ b/deploy/infra/vault-docker-compose.yml
@@ -5,6 +5,7 @@ services:
 #    depends_on:
 #      - consul
     image: vault
+    container_name: vault
     hostname: vault
 #    links:
 #      - consul:consul
@@ -22,3 +23,7 @@ services:
       - ./docs/docker-compose/vault-consul/config/vault:/config
       - ./docs/docker-compose/vault-consul/config/vault/policies:/policies
     entrypoint: /wait-for-it.sh -t 20 -h consul -p 8500 -s -- vault server -config=/config/with-consul.hcl
+networks:
+  default:
+    external:
+      name: ocelot

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,6 @@ services:
       options:
         max-size: "200k"
         max-file: "10"
-        #    volumes:
-        #      - "/etc/letsencrypt/live/ocelot.hq.l11.com/privkey.pem:/etc/letsencrypt/live/ocelot.hq.l11.com/privkey.pem"
     ports:
       - "10000:10000"
     environment:
@@ -27,11 +25,6 @@ services:
       CONSUL_HOST: http://consul
       NSQLOOKUPD_IP: nsqlookupd
       NSQD_IP: nsqd
-#      VAULT_TOKEN: 60fa5ed4-2e0c-cf78-b5db-1e6f495f947b
-#      VAULT_ADDR: http://172.18.0.1:8200
-#      CONSUL_HOST: http://172.17.0.1
-#      NSQLOOKUPD_IP: 172.18.0.1
-#      NSQD_IP: 172.18.0.1
 
   hookhandler:
     image: ocelot-hookhandler
@@ -54,18 +47,10 @@ services:
     environment:
       VAULT_TOKEN: ${VAULT_TOKEN}
       VAULT_ADDR: http://vault:8200
-#      CONSUL_HTTP_ADDR: http://172.18.0.1:8500
       CONSUL_HOST: http://consul
       LOG_LEVEL: debug
       NSQD_IP: nsqd
       NSQLOOKUPD_IP: nsqlookupd
-#      VAULT_TOKEN: 60fa5ed4-2e0c-cf78-b5db-1e6f495f947b
-#      VAULT_ADDR: http://172.18.0.1:8200
-##      CONSUL_HTTP_ADDR: http://172.18.0.1:8500
-#      CONSUL_HOST: http://172.17.0.1
-#      LOG_LEVEL: debug
-#      NSQD_IP: 172.17.0.1
-#      NSQLOOKUPD_IP: 172.17.0.1
 
   werker:
     image: ocelot-werker
@@ -89,13 +74,6 @@ services:
       NSQD_IP: nsdq
       NSQLOOKUPD_IP: nsqlookupd
       REGISTER_IP: 10.1.62.38
-#      VAULT_TOKEN: 60fa5ed4-2e0c-cf78-b5db-1e6f495f947b
-#      VAULT_ADDR: http://172.18.0.1:8200
-#      CONSUL_HTTP_ADDR: http://172.17.0.1:8500
-#      CONSUL_HOST: 172.18.0.1
-#      NSQD_IP: 172.17.0.1
-#      NSQLOOKUPD_IP: 172.17.0.1
-#      REGISTER_IP: ec2-34-212-13-136.us-west-2.compute.amazonaws.com
     logging:
       driver: "json-file"
       options:
@@ -119,12 +97,6 @@ services:
       CONSUL_HOST: consul
       NSQD_IP: nsqd
       NSQLOOKUPD_IP: nsqlookupd
-#      VAULT_TOKEN: 60fa5ed4-2e0c-cf78-b5db-1e6f495f947b
-#      VAULT_ADDR: http://172.18.0.1:8200
-#      CONSUL_HTTP_ADDR: http://172.17.0.1:8500
-#      CONSUL_HOST: 172.18.0.1
-#      NSQD_IP: 172.17.0.1
-#      NSQLOOKUPD_IP: 172.17.0.1
     logging:
       driver: "json-file"
       options:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,29 +3,39 @@ services:
   # Ocelot services
   admin:
     image: ocelot-admin
+    container_name: admin
     command: /admin -log-level=debug
     build:
       context: .
       dockerfile: cmd/admin/Dockerfile
       cache_from:
         - golang:1.9-alpine
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"
     logging:
       driver: "json-file"
       options:
         max-size: "200k"
         max-file: "10"
-    volumes:
-      - "/etc/letsencrypt/live/ocelot.hq.l11.com/privkey.pem:/etc/letsencrypt/live/ocelot.hq.l11.com/privkey.pem"
+        #    volumes:
+        #      - "/etc/letsencrypt/live/ocelot.hq.l11.com/privkey.pem:/etc/letsencrypt/live/ocelot.hq.l11.com/privkey.pem"
     ports:
       - "10000:10000"
     environment:
-      VAULT_TOKEN: 60fa5ed4-2e0c-cf78-b5db-1e6f495f947b
-      VAULT_ADDR: http://172.18.0.1:8200
-      CONSUL_HOST: http://172.17.0.1
-      NSQLOOKUPD_IP: 172.18.0.1
-      NSQD_IP: 172.18.0.1
+      VAULT_TOKEN: ${VAULT_TOKEN}
+      VAULT_ADDR: http://vault:8200
+      CONSUL_HOST: http://consul
+      NSQLOOKUPD_IP: nsqlookupd
+      NSQD_IP: nsqd
+#      VAULT_TOKEN: 60fa5ed4-2e0c-cf78-b5db-1e6f495f947b
+#      VAULT_ADDR: http://172.18.0.1:8200
+#      CONSUL_HOST: http://172.17.0.1
+#      NSQLOOKUPD_IP: 172.18.0.1
+#      NSQD_IP: 172.18.0.1
+
   hookhandler:
     image: ocelot-hookhandler
+    container_name: hookhandler
     command: /hookhandler 
     build:
       context: .
@@ -42,27 +52,43 @@ services:
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
     environment:
-      VAULT_TOKEN: 60fa5ed4-2e0c-cf78-b5db-1e6f495f947b
-      VAULT_ADDR: http://172.18.0.1:8200
+      VAULT_TOKEN: ${VAULT_TOKEN}
+      VAULT_ADDR: http://vault:8200
 #      CONSUL_HTTP_ADDR: http://172.18.0.1:8500
-      CONSUL_HOST: http://172.17.0.1
+      CONSUL_HOST: http://consul
       LOG_LEVEL: debug
-      NSQD_IP: 172.17.0.1
-      NSQLOOKUPD_IP: 172.17.0.1
-#  werker:
-#    image: ocelot-werker
-#    command: /werker -log-level debug
-#    build:
-#      context: .
-#      dockerfile: werker/Dockerfile
-#      cache_from:
-#        - golang:1.9-alpine
-#    ports:
-#      - "9090:9090"
-#      - "9099:9099"
-#    volumes:
-#      - "/var/run/docker.sock:/var/run/docker.sock"
-#    environment:
+      NSQD_IP: nsqd
+      NSQLOOKUPD_IP: nsqlookupd
+#      VAULT_TOKEN: 60fa5ed4-2e0c-cf78-b5db-1e6f495f947b
+#      VAULT_ADDR: http://172.18.0.1:8200
+##      CONSUL_HTTP_ADDR: http://172.18.0.1:8500
+#      CONSUL_HOST: http://172.17.0.1
+#      LOG_LEVEL: debug
+#      NSQD_IP: 172.17.0.1
+#      NSQLOOKUPD_IP: 172.17.0.1
+
+  werker:
+    image: ocelot-werker
+    container_name: werker
+    command: /werker -log-level debug
+    build:
+      context: .
+      dockerfile: cmd/werker/Dockerfile
+      cache_from:
+        - golang:1.9-alpine
+    ports:
+      - "9090:9090"
+      - "9099:9099"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    environment:
+      VAULT_TOKEN: ${VAULT_TOKEN}
+      VAULT_ADDR: http://vault:8200
+      CONSUL_HTTP_ADDR: http://consul:8500
+      CONSUL_HOST: consul
+      NSQD_IP: nsdq
+      NSQLOOKUPD_IP: nsqlookupd
+      REGISTER_IP: 10.1.62.38
 #      VAULT_TOKEN: 60fa5ed4-2e0c-cf78-b5db-1e6f495f947b
 #      VAULT_ADDR: http://172.18.0.1:8200
 #      CONSUL_HTTP_ADDR: http://172.17.0.1:8500
@@ -70,13 +96,15 @@ services:
 #      NSQD_IP: 172.17.0.1
 #      NSQLOOKUPD_IP: 172.17.0.1
 #      REGISTER_IP: ec2-34-212-13-136.us-west-2.compute.amazonaws.com
-#    logging:
-#      driver: "json-file"
-#      options:
-#        max-size: "200k"
-#        max-file: "10"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "200k"
+        max-file: "10"
+
   poller:
     image: ocelot-poller
+    container_name: poller
     build:
       context: .
       dockerfile: cmd/poller/Dockerfile
@@ -85,15 +113,25 @@ services:
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
     environment:
-      VAULT_TOKEN: 60fa5ed4-2e0c-cf78-b5db-1e6f495f947b
-      VAULT_ADDR: http://172.18.0.1:8200
-      CONSUL_HTTP_ADDR: http://172.17.0.1:8500
-      CONSUL_HOST: 172.18.0.1
-      NSQD_IP: 172.17.0.1
-      NSQLOOKUPD_IP: 172.17.0.1
+      VAULT_TOKEN: ${VAULT_TOKEN}
+      VAULT_ADDR: http://vault:8200
+      CONSUL_HTTP_ADDR: http://consul:8500
+      CONSUL_HOST: consul
+      NSQD_IP: nsqd
+      NSQLOOKUPD_IP: nsqlookupd
+#      VAULT_TOKEN: 60fa5ed4-2e0c-cf78-b5db-1e6f495f947b
+#      VAULT_ADDR: http://172.18.0.1:8200
+#      CONSUL_HTTP_ADDR: http://172.17.0.1:8500
+#      CONSUL_HOST: 172.18.0.1
+#      NSQD_IP: 172.17.0.1
+#      NSQLOOKUPD_IP: 172.17.0.1
     logging:
       driver: "json-file"
       options:
         max-size: "200k"
         max-file: "10"
 
+networks:
+  default:
+    external:
+      name: ocelot

--- a/models/bitbucket/pb/common.pb.go
+++ b/models/bitbucket/pb/common.pb.go
@@ -19,7 +19,7 @@ var _ = math.Inf
 const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
 type LinkUrl struct {
-	Href                 string   `protobuf:"bytes,1,opt,name=href" json:"href,omitempty"`
+	Href                 string   `protobuf:"bytes,1,opt,name=href,proto3" json:"href,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -57,8 +57,8 @@ func (m *LinkUrl) GetHref() string {
 }
 
 type LinkAndName struct {
-	Href                 string   `protobuf:"bytes,1,opt,name=href" json:"href,omitempty"`
-	Name                 string   `protobuf:"bytes,2,opt,name=name" json:"name,omitempty"`
+	Href                 string   `protobuf:"bytes,1,opt,name=href,proto3" json:"href,omitempty"`
+	Name                 string   `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -103,9 +103,9 @@ func (m *LinkAndName) GetName() string {
 }
 
 type Links struct {
-	Self                 *LinkUrl `protobuf:"bytes,1,opt,name=self" json:"self,omitempty"`
-	Html                 *LinkUrl `protobuf:"bytes,2,opt,name=html" json:"html,omitempty"`
-	Avatar               *LinkUrl `protobuf:"bytes,3,opt,name=avatar" json:"avatar,omitempty"`
+	Self                 *LinkUrl `protobuf:"bytes,1,opt,name=self,proto3" json:"self,omitempty"`
+	Html                 *LinkUrl `protobuf:"bytes,2,opt,name=html,proto3" json:"html,omitempty"`
+	Avatar               *LinkUrl `protobuf:"bytes,3,opt,name=avatar,proto3" json:"avatar,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`

--- a/models/bitbucket/pb/commonevententities.pb.go
+++ b/models/bitbucket/pb/commonevententities.pb.go
@@ -21,9 +21,9 @@ const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
 // https://confluence.atlassian.com/bitbucket/event-payloads-740262817.html#EventPayloads-entity_userOwner
 type Owner struct {
-	Type                 string   `protobuf:"bytes,1,opt,name=type" json:"type,omitempty"`
-	Username             string   `protobuf:"bytes,2,opt,name=username" json:"username,omitempty"`
-	Links                *Links   `protobuf:"bytes,3,opt,name=links" json:"links,omitempty"`
+	Type                 string   `protobuf:"bytes,1,opt,name=type,proto3" json:"type,omitempty"`
+	Username             string   `protobuf:"bytes,2,opt,name=username,proto3" json:"username,omitempty"`
+	Links                *Links   `protobuf:"bytes,3,opt,name=links,proto3" json:"links,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -76,11 +76,11 @@ func (m *Owner) GetLinks() *Links {
 
 // https://confluence.atlassian.com/bitbucket/event-payloads-740262817.html#EventPayloads-entity_repositoryRepository
 type Repository struct {
-	Links                *Links   `protobuf:"bytes,1,opt,name=links" json:"links,omitempty"`
-	Project              *Project `protobuf:"bytes,2,opt,name=project" json:"project,omitempty"`
-	FullName             string   `protobuf:"bytes,3,opt,name=fullName,json=full_name" json:"fullName,omitempty"`
-	Website              string   `protobuf:"bytes,4,opt,name=website" json:"website,omitempty"`
-	Owner                *Owner   `protobuf:"bytes,5,opt,name=owner" json:"owner,omitempty"`
+	Links                *Links   `protobuf:"bytes,1,opt,name=links,proto3" json:"links,omitempty"`
+	Project              *Project `protobuf:"bytes,2,opt,name=project,proto3" json:"project,omitempty"`
+	FullName             string   `protobuf:"bytes,3,opt,name=fullName,json=full_name,proto3" json:"fullName,omitempty"`
+	Website              string   `protobuf:"bytes,4,opt,name=website,proto3" json:"website,omitempty"`
+	Owner                *Owner   `protobuf:"bytes,5,opt,name=owner,proto3" json:"owner,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -147,22 +147,22 @@ func (m *Repository) GetOwner() *Owner {
 
 // https://confluence.atlassian.com/bitbucket/event-payloads-740262817.html#EventPayloads-Pullrequestevents
 type PullRequestEntity struct {
-	Id                   int64                `protobuf:"varint,1,opt,name=id" json:"id,omitempty"`
-	Title                string               `protobuf:"bytes,2,opt,name=title" json:"title,omitempty"`
-	Description          string               `protobuf:"bytes,3,opt,name=description" json:"description,omitempty"`
-	State                string               `protobuf:"bytes,4,opt,name=state" json:"state,omitempty"`
-	Author               *Owner               `protobuf:"bytes,5,opt,name=author" json:"author,omitempty"`
-	Source               *PRInfo              `protobuf:"bytes,6,opt,name=source" json:"source,omitempty"`
-	Destination          *PRInfo              `protobuf:"bytes,7,opt,name=destination" json:"destination,omitempty"`
-	MergeCommit          *Commit              `protobuf:"bytes,8,opt,name=mergeCommit,json=merge_commit" json:"mergeCommit,omitempty"`
-	Participants         []*Owner             `protobuf:"bytes,9,rep,name=participants" json:"participants,omitempty"`
-	Reviewers            []*Owner             `protobuf:"bytes,10,rep,name=reviewers" json:"reviewers,omitempty"`
-	CloseSourceBranch    bool                 `protobuf:"varint,11,opt,name=closeSourceBranch,json=close_source_branch" json:"closeSourceBranch,omitempty"`
-	ClosedBy             *Owner               `protobuf:"bytes,12,opt,name=closedBy,json=closed_by" json:"closedBy,omitempty"`
-	Reason               string               `protobuf:"bytes,13,opt,name=reason" json:"reason,omitempty"`
-	CreatedAt            *timestamp.Timestamp `protobuf:"bytes,14,opt,name=createdAt,json=created_at" json:"createdAt,omitempty"`
-	UpdatedOn            *timestamp.Timestamp `protobuf:"bytes,15,opt,name=updatedOn,json=updated_on" json:"updatedOn,omitempty"`
-	Links                *Links               `protobuf:"bytes,16,opt,name=links" json:"links,omitempty"`
+	Id                   int64                `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	Title                string               `protobuf:"bytes,2,opt,name=title,proto3" json:"title,omitempty"`
+	Description          string               `protobuf:"bytes,3,opt,name=description,proto3" json:"description,omitempty"`
+	State                string               `protobuf:"bytes,4,opt,name=state,proto3" json:"state,omitempty"`
+	Author               *Owner               `protobuf:"bytes,5,opt,name=author,proto3" json:"author,omitempty"`
+	Source               *PRInfo              `protobuf:"bytes,6,opt,name=source,proto3" json:"source,omitempty"`
+	Destination          *PRInfo              `protobuf:"bytes,7,opt,name=destination,proto3" json:"destination,omitempty"`
+	MergeCommit          *Commit              `protobuf:"bytes,8,opt,name=mergeCommit,json=merge_commit,proto3" json:"mergeCommit,omitempty"`
+	Participants         []*Owner             `protobuf:"bytes,9,rep,name=participants,proto3" json:"participants,omitempty"`
+	Reviewers            []*Owner             `protobuf:"bytes,10,rep,name=reviewers,proto3" json:"reviewers,omitempty"`
+	CloseSourceBranch    bool                 `protobuf:"varint,11,opt,name=closeSourceBranch,json=close_source_branch,proto3" json:"closeSourceBranch,omitempty"`
+	ClosedBy             *Owner               `protobuf:"bytes,12,opt,name=closedBy,json=closed_by,proto3" json:"closedBy,omitempty"`
+	Reason               string               `protobuf:"bytes,13,opt,name=reason,proto3" json:"reason,omitempty"`
+	CreatedAt            *timestamp.Timestamp `protobuf:"bytes,14,opt,name=createdAt,json=created_at,proto3" json:"createdAt,omitempty"`
+	UpdatedOn            *timestamp.Timestamp `protobuf:"bytes,15,opt,name=updatedOn,json=updated_on,proto3" json:"updatedOn,omitempty"`
+	Links                *Links               `protobuf:"bytes,16,opt,name=links,proto3" json:"links,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}             `json:"-"`
 	XXX_unrecognized     []byte               `json:"-"`
 	XXX_sizecache        int32                `json:"-"`
@@ -305,9 +305,9 @@ func (m *PullRequestEntity) GetLinks() *Links {
 }
 
 type PRInfo struct {
-	Branch               *PRInfoBr   `protobuf:"bytes,1,opt,name=branch" json:"branch,omitempty"`
-	Commit               *Commit     `protobuf:"bytes,2,opt,name=commit" json:"commit,omitempty"`
-	Repository           *Repository `protobuf:"bytes,3,opt,name=repository" json:"repository,omitempty"`
+	Branch               *PRInfoBr   `protobuf:"bytes,1,opt,name=branch,proto3" json:"branch,omitempty"`
+	Commit               *Commit     `protobuf:"bytes,2,opt,name=commit,proto3" json:"commit,omitempty"`
+	Repository           *Repository `protobuf:"bytes,3,opt,name=repository,proto3" json:"repository,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}    `json:"-"`
 	XXX_unrecognized     []byte      `json:"-"`
 	XXX_sizecache        int32       `json:"-"`
@@ -359,7 +359,7 @@ func (m *PRInfo) GetRepository() *Repository {
 }
 
 type PRInfoBr struct {
-	Name                 string   `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
+	Name                 string   `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -398,9 +398,9 @@ func (m *PRInfoBr) GetName() string {
 
 // https://confluence.atlassian.com/bitbucket/event-payloads-740262817.html#EventPayloads-entity_projectProject
 type Project struct {
-	Name                 string   `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
-	Uuid                 string   `protobuf:"bytes,2,opt,name=uuid" json:"uuid,omitempty"`
-	Links                *Links   `protobuf:"bytes,3,opt,name=links" json:"links,omitempty"`
+	Name                 string   `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Uuid                 string   `protobuf:"bytes,2,opt,name=uuid,proto3" json:"uuid,omitempty"`
+	Links                *Links   `protobuf:"bytes,3,opt,name=links,proto3" json:"links,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -452,13 +452,13 @@ func (m *Project) GetLinks() *Links {
 }
 
 type Changeset struct {
-	New                  *Changeset_Head `protobuf:"bytes,1,opt,name=new" json:"new,omitempty"`
-	Old                  *Changeset_Head `protobuf:"bytes,2,opt,name=old" json:"old,omitempty"`
-	Links                *Links          `protobuf:"bytes,3,opt,name=links" json:"links,omitempty"`
-	Closed               bool            `protobuf:"varint,4,opt,name=closed" json:"closed,omitempty"`
-	Created              bool            `protobuf:"varint,5,opt,name=created" json:"created,omitempty"`
-	Forced               bool            `protobuf:"varint,6,opt,name=forced" json:"forced,omitempty"`
-	Commits              []*Commit       `protobuf:"bytes,7,rep,name=commits" json:"commits,omitempty"`
+	New                  *Changeset_Head `protobuf:"bytes,1,opt,name=new,proto3" json:"new,omitempty"`
+	Old                  *Changeset_Head `protobuf:"bytes,2,opt,name=old,proto3" json:"old,omitempty"`
+	Links                *Links          `protobuf:"bytes,3,opt,name=links,proto3" json:"links,omitempty"`
+	Closed               bool            `protobuf:"varint,4,opt,name=closed,proto3" json:"closed,omitempty"`
+	Created              bool            `protobuf:"varint,5,opt,name=created,proto3" json:"created,omitempty"`
+	Forced               bool            `protobuf:"varint,6,opt,name=forced,proto3" json:"forced,omitempty"`
+	Commits              []*Commit       `protobuf:"bytes,7,rep,name=commits,proto3" json:"commits,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}        `json:"-"`
 	XXX_unrecognized     []byte          `json:"-"`
 	XXX_sizecache        int32           `json:"-"`
@@ -538,9 +538,9 @@ func (m *Changeset) GetCommits() []*Commit {
 }
 
 type Changeset_Head struct {
-	Type                 string   `protobuf:"bytes,1,opt,name=type" json:"type,omitempty"`
-	Name                 string   `protobuf:"bytes,2,opt,name=name" json:"name,omitempty"`
-	Target               *Commit  `protobuf:"bytes,3,opt,name=target" json:"target,omitempty"`
+	Type                 string   `protobuf:"bytes,1,opt,name=type,proto3" json:"type,omitempty"`
+	Name                 string   `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	Target               *Commit  `protobuf:"bytes,3,opt,name=target,proto3" json:"target,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -592,13 +592,13 @@ func (m *Changeset_Head) GetTarget() *Commit {
 }
 
 type Commit struct {
-	Hash    string               `protobuf:"bytes,1,opt,name=hash" json:"hash,omitempty"`
-	Author  *Owner               `protobuf:"bytes,2,opt,name=author" json:"author,omitempty"`
-	Message string               `protobuf:"bytes,3,opt,name=message" json:"message,omitempty"`
-	Date    *timestamp.Timestamp `protobuf:"bytes,4,opt,name=date" json:"date,omitempty"`
+	Hash    string               `protobuf:"bytes,1,opt,name=hash,proto3" json:"hash,omitempty"`
+	Author  *Owner               `protobuf:"bytes,2,opt,name=author,proto3" json:"author,omitempty"`
+	Message string               `protobuf:"bytes,3,opt,name=message,proto3" json:"message,omitempty"`
+	Date    *timestamp.Timestamp `protobuf:"bytes,4,opt,name=date,proto3" json:"date,omitempty"`
 	// ignoring the "parents" field
-	Links                *Links      `protobuf:"bytes,5,opt,name=links" json:"links,omitempty"`
-	Repository           *Repository `protobuf:"bytes,6,opt,name=repository" json:"repository,omitempty"`
+	Links                *Links      `protobuf:"bytes,5,opt,name=links,proto3" json:"links,omitempty"`
+	Repository           *Repository `protobuf:"bytes,6,opt,name=repository,proto3" json:"repository,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}    `json:"-"`
 	XXX_unrecognized     []byte      `json:"-"`
 	XXX_sizecache        int32       `json:"-"`
@@ -672,7 +672,7 @@ func (m *Commit) GetRepository() *Repository {
 
 // /2.0/repositories/{username}/{repo_slug}/commits
 type Commits struct {
-	Values               []*Commit `protobuf:"bytes,1,rep,name=values" json:"values,omitempty"`
+	Values               []*Commit `protobuf:"bytes,1,rep,name=values,proto3" json:"values,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}  `json:"-"`
 	XXX_unrecognized     []byte    `json:"-"`
 	XXX_sizecache        int32     `json:"-"`
@@ -712,9 +712,9 @@ func (m *Commits) GetValues() []*Commit {
 // bitbucket api 1.0
 // https://confluence.atlassian.com/bitbucket/src-resources-296095214.html
 type RepoSourceFile struct {
-	Node                 string   `protobuf:"bytes,1,opt,name=node" json:"node,omitempty"`
-	Path                 string   `protobuf:"bytes,2,opt,name=path" json:"path,omitempty"`
-	Data                 string   `protobuf:"bytes,3,opt,name=data" json:"data,omitempty"`
+	Node                 string   `protobuf:"bytes,1,opt,name=node,proto3" json:"node,omitempty"`
+	Path                 string   `protobuf:"bytes,2,opt,name=path,proto3" json:"path,omitempty"`
+	Data                 string   `protobuf:"bytes,3,opt,name=data,proto3" json:"data,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -766,9 +766,9 @@ func (m *RepoSourceFile) GetData() string {
 }
 
 type Author struct {
-	Raw                  string   `protobuf:"bytes,1,opt,name=raw" json:"raw,omitempty"`
-	Type                 string   `protobuf:"bytes,2,opt,name=type" json:"type,omitempty"`
-	User                 *Owner   `protobuf:"bytes,3,opt,name=user" json:"user,omitempty"`
+	Raw                  string   `protobuf:"bytes,1,opt,name=raw,proto3" json:"raw,omitempty"`
+	Type                 string   `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
+	User                 *Owner   `protobuf:"bytes,3,opt,name=user,proto3" json:"user,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`

--- a/models/bitbucket/pb/projectrootdir.pb.go
+++ b/models/bitbucket/pb/projectrootdir.pb.go
@@ -19,11 +19,11 @@ var _ = math.Inf
 const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
 type PaginatedRootDirs struct {
-	Pagelen              float64                           `protobuf:"fixed64,1,opt,name=pagelen" json:"pagelen,omitempty"`
-	Size                 float64                           `protobuf:"fixed64,2,opt,name=size" json:"size,omitempty"`
-	Values               []*PaginatedRootDirs_SourceValues `protobuf:"bytes,3,rep,name=values" json:"values,omitempty"`
-	Page                 float64                           `protobuf:"fixed64,4,opt,name=page" json:"page,omitempty"`
-	Next                 string                            `protobuf:"bytes,5,opt,name=next" json:"next,omitempty"`
+	Pagelen              float64                           `protobuf:"fixed64,1,opt,name=pagelen,proto3" json:"pagelen,omitempty"`
+	Size                 float64                           `protobuf:"fixed64,2,opt,name=size,proto3" json:"size,omitempty"`
+	Values               []*PaginatedRootDirs_SourceValues `protobuf:"bytes,3,rep,name=values,proto3" json:"values,omitempty"`
+	Page                 float64                           `protobuf:"fixed64,4,opt,name=page,proto3" json:"page,omitempty"`
+	Next                 string                            `protobuf:"bytes,5,opt,name=next,proto3" json:"next,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                          `json:"-"`
 	XXX_unrecognized     []byte                            `json:"-"`
 	XXX_sizecache        int32                             `json:"-"`
@@ -89,10 +89,10 @@ func (m *PaginatedRootDirs) GetNext() string {
 }
 
 type PaginatedRootDirs_SourceValues struct {
-	Path                 string                                      `protobuf:"bytes,1,opt,name=path" json:"path,omitempty"`
-	Type                 string                                      `protobuf:"bytes,2,opt,name=type" json:"type,omitempty"`
-	Attributes           []string                                    `protobuf:"bytes,3,rep,name=attributes" json:"attributes,omitempty"`
-	Links                *PaginatedRootDirs_SourceValues_SourceLinks `protobuf:"bytes,4,opt,name=links" json:"links,omitempty"`
+	Path                 string                                      `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
+	Type                 string                                      `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
+	Attributes           []string                                    `protobuf:"bytes,3,rep,name=attributes,proto3" json:"attributes,omitempty"`
+	Links                *PaginatedRootDirs_SourceValues_SourceLinks `protobuf:"bytes,4,opt,name=links,proto3" json:"links,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                                    `json:"-"`
 	XXX_unrecognized     []byte                                      `json:"-"`
 	XXX_sizecache        int32                                       `json:"-"`
@@ -151,8 +151,8 @@ func (m *PaginatedRootDirs_SourceValues) GetLinks() *PaginatedRootDirs_SourceVal
 }
 
 type PaginatedRootDirs_SourceValues_SourceLinks struct {
-	Self                 *LinkUrl `protobuf:"bytes,1,opt,name=self" json:"self,omitempty"`
-	Meta                 *LinkUrl `protobuf:"bytes,2,opt,name=meta" json:"meta,omitempty"`
+	Self                 *LinkUrl `protobuf:"bytes,1,opt,name=self,proto3" json:"self,omitempty"`
+	Meta                 *LinkUrl `protobuf:"bytes,2,opt,name=meta,proto3" json:"meta,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`

--- a/models/bitbucket/pb/respositories.pb.go
+++ b/models/bitbucket/pb/respositories.pb.go
@@ -20,11 +20,11 @@ var _ = math.Inf
 const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
 type PaginatedRepository struct {
-	Pagelen              float64                                 `protobuf:"fixed64,1,opt,name=pagelen" json:"pagelen,omitempty"`
-	Size                 float64                                 `protobuf:"fixed64,2,opt,name=size" json:"size,omitempty"`
-	Values               []*PaginatedRepository_RepositoryValues `protobuf:"bytes,3,rep,name=values" json:"values,omitempty"`
-	Page                 float64                                 `protobuf:"fixed64,4,opt,name=page" json:"page,omitempty"`
-	Next                 string                                  `protobuf:"bytes,5,opt,name=next" json:"next,omitempty"`
+	Pagelen              float64                                 `protobuf:"fixed64,1,opt,name=pagelen,proto3" json:"pagelen,omitempty"`
+	Size                 float64                                 `protobuf:"fixed64,2,opt,name=size,proto3" json:"size,omitempty"`
+	Values               []*PaginatedRepository_RepositoryValues `protobuf:"bytes,3,rep,name=values,proto3" json:"values,omitempty"`
+	Page                 float64                                 `protobuf:"fixed64,4,opt,name=page,proto3" json:"page,omitempty"`
+	Next                 string                                  `protobuf:"bytes,5,opt,name=next,proto3" json:"next,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                                `json:"-"`
 	XXX_unrecognized     []byte                                  `json:"-"`
 	XXX_sizecache        int32                                   `json:"-"`
@@ -90,18 +90,18 @@ func (m *PaginatedRepository) GetNext() string {
 }
 
 type PaginatedRepository_RepositoryValues struct {
-	Name                 string                                                `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
-	Links                *PaginatedRepository_RepositoryValues_RepositoryLinks `protobuf:"bytes,2,opt,name=links" json:"links,omitempty"`
-	Project              *PaginatedRepository_RepositoryValues_Project         `protobuf:"bytes,3,opt,name=project" json:"project,omitempty"`
-	CreatedOn            *timestamp.Timestamp                                  `protobuf:"bytes,4,opt,name=created_on,json=createdOn" json:"created_on,omitempty"`
-	Mainbranch           *PaginatedRepository_RepositoryValues_MainBranch      `protobuf:"bytes,5,opt,name=mainbranch" json:"mainbranch,omitempty"`
-	FullName             string                                                `protobuf:"bytes,6,opt,name=full_name,json=fullName" json:"full_name,omitempty"`
-	UpdatedOn            *timestamp.Timestamp                                  `protobuf:"bytes,7,opt,name=updated_on,json=updatedOn" json:"updated_on,omitempty"`
-	Size                 float64                                               `protobuf:"fixed64,8,opt,name=size" json:"size,omitempty"`
-	Type                 string                                                `protobuf:"bytes,9,opt,name=type" json:"type,omitempty"`
-	Slug                 string                                                `protobuf:"bytes,10,opt,name=slug" json:"slug,omitempty"`
-	IsPrivate            bool                                                  `protobuf:"varint,11,opt,name=is_private,json=isPrivate" json:"is_private,omitempty"`
-	Description          string                                                `protobuf:"bytes,12,opt,name=description" json:"description,omitempty"`
+	Name                 string                                                `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Links                *PaginatedRepository_RepositoryValues_RepositoryLinks `protobuf:"bytes,2,opt,name=links,proto3" json:"links,omitempty"`
+	Project              *PaginatedRepository_RepositoryValues_Project         `protobuf:"bytes,3,opt,name=project,proto3" json:"project,omitempty"`
+	CreatedOn            *timestamp.Timestamp                                  `protobuf:"bytes,4,opt,name=created_on,json=createdOn,proto3" json:"created_on,omitempty"`
+	Mainbranch           *PaginatedRepository_RepositoryValues_MainBranch      `protobuf:"bytes,5,opt,name=mainbranch,proto3" json:"mainbranch,omitempty"`
+	FullName             string                                                `protobuf:"bytes,6,opt,name=full_name,json=fullName,proto3" json:"full_name,omitempty"`
+	UpdatedOn            *timestamp.Timestamp                                  `protobuf:"bytes,7,opt,name=updated_on,json=updatedOn,proto3" json:"updated_on,omitempty"`
+	Size                 float64                                               `protobuf:"fixed64,8,opt,name=size,proto3" json:"size,omitempty"`
+	Type                 string                                                `protobuf:"bytes,9,opt,name=type,proto3" json:"type,omitempty"`
+	Slug                 string                                                `protobuf:"bytes,10,opt,name=slug,proto3" json:"slug,omitempty"`
+	IsPrivate            bool                                                  `protobuf:"varint,11,opt,name=is_private,json=isPrivate,proto3" json:"is_private,omitempty"`
+	Description          string                                                `protobuf:"bytes,12,opt,name=description,proto3" json:"description,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                                              `json:"-"`
 	XXX_unrecognized     []byte                                                `json:"-"`
 	XXX_sizecache        int32                                                 `json:"-"`
@@ -216,17 +216,17 @@ func (m *PaginatedRepository_RepositoryValues) GetDescription() string {
 }
 
 type PaginatedRepository_RepositoryValues_RepositoryLinks struct {
-	Watchers             *LinkUrl       `protobuf:"bytes,1,opt,name=watchers" json:"watchers,omitempty"`
-	Branches             *LinkUrl       `protobuf:"bytes,2,opt,name=branches" json:"branches,omitempty"`
-	Tags                 *LinkUrl       `protobuf:"bytes,3,opt,name=tags" json:"tags,omitempty"`
-	Commits              *LinkUrl       `protobuf:"bytes,4,opt,name=commits" json:"commits,omitempty"`
-	Clone                []*LinkAndName `protobuf:"bytes,5,rep,name=clone" json:"clone,omitempty"`
-	Self                 *LinkUrl       `protobuf:"bytes,6,opt,name=self" json:"self,omitempty"`
-	Source               *LinkUrl       `protobuf:"bytes,7,opt,name=source" json:"source,omitempty"`
-	Hooks                *LinkUrl       `protobuf:"bytes,8,opt,name=hooks" json:"hooks,omitempty"`
-	Forks                *LinkUrl       `protobuf:"bytes,9,opt,name=forks" json:"forks,omitempty"`
-	Downloads            *LinkUrl       `protobuf:"bytes,10,opt,name=downloads" json:"downloads,omitempty"`
-	Pullrequests         *LinkUrl       `protobuf:"bytes,11,opt,name=pullrequests" json:"pullrequests,omitempty"`
+	Watchers             *LinkUrl       `protobuf:"bytes,1,opt,name=watchers,proto3" json:"watchers,omitempty"`
+	Branches             *LinkUrl       `protobuf:"bytes,2,opt,name=branches,proto3" json:"branches,omitempty"`
+	Tags                 *LinkUrl       `protobuf:"bytes,3,opt,name=tags,proto3" json:"tags,omitempty"`
+	Commits              *LinkUrl       `protobuf:"bytes,4,opt,name=commits,proto3" json:"commits,omitempty"`
+	Clone                []*LinkAndName `protobuf:"bytes,5,rep,name=clone,proto3" json:"clone,omitempty"`
+	Self                 *LinkUrl       `protobuf:"bytes,6,opt,name=self,proto3" json:"self,omitempty"`
+	Source               *LinkUrl       `protobuf:"bytes,7,opt,name=source,proto3" json:"source,omitempty"`
+	Hooks                *LinkUrl       `protobuf:"bytes,8,opt,name=hooks,proto3" json:"hooks,omitempty"`
+	Forks                *LinkUrl       `protobuf:"bytes,9,opt,name=forks,proto3" json:"forks,omitempty"`
+	Downloads            *LinkUrl       `protobuf:"bytes,10,opt,name=downloads,proto3" json:"downloads,omitempty"`
+	Pullrequests         *LinkUrl       `protobuf:"bytes,11,opt,name=pullrequests,proto3" json:"pullrequests,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}       `json:"-"`
 	XXX_unrecognized     []byte         `json:"-"`
 	XXX_sizecache        int32          `json:"-"`
@@ -338,11 +338,11 @@ func (m *PaginatedRepository_RepositoryValues_RepositoryLinks) GetPullrequests()
 }
 
 type PaginatedRepository_RepositoryValues_Project struct {
-	Key                  string                                                `protobuf:"bytes,1,opt,name=key" json:"key,omitempty"`
-	Type                 string                                                `protobuf:"bytes,2,opt,name=type" json:"type,omitempty"`
-	Uuid                 string                                                `protobuf:"bytes,3,opt,name=uuid" json:"uuid,omitempty"`
-	Links                *PaginatedRepository_RepositoryValues_RepositoryLinks `protobuf:"bytes,4,opt,name=links" json:"links,omitempty"`
-	Name                 string                                                `protobuf:"bytes,5,opt,name=name" json:"name,omitempty"`
+	Key                  string                                                `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	Type                 string                                                `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
+	Uuid                 string                                                `protobuf:"bytes,3,opt,name=uuid,proto3" json:"uuid,omitempty"`
+	Links                *PaginatedRepository_RepositoryValues_RepositoryLinks `protobuf:"bytes,4,opt,name=links,proto3" json:"links,omitempty"`
+	Name                 string                                                `protobuf:"bytes,5,opt,name=name,proto3" json:"name,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                                              `json:"-"`
 	XXX_unrecognized     []byte                                                `json:"-"`
 	XXX_sizecache        int32                                                 `json:"-"`
@@ -412,8 +412,8 @@ func (m *PaginatedRepository_RepositoryValues_Project) GetName() string {
 }
 
 type PaginatedRepository_RepositoryValues_MainBranch struct {
-	Type                 string   `protobuf:"bytes,1,opt,name=type" json:"type,omitempty"`
-	Name                 string   `protobuf:"bytes,2,opt,name=name" json:"name,omitempty"`
+	Type                 string   `protobuf:"bytes,1,opt,name=type,proto3" json:"type,omitempty"`
+	Name                 string   `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -465,11 +465,11 @@ func (m *PaginatedRepository_RepositoryValues_MainBranch) GetName() string {
 // see https://confluence.atlassian.com/bitbucket/changesets-resource-296095208.html#changesetsResource-GETanindividualchangeset
 // for a list of avilable data on changesets
 type ChangeSetV1 struct {
-	Node                 string   `protobuf:"bytes,1,opt,name=node" json:"node,omitempty"`
-	RawAuthor            string   `protobuf:"bytes,2,opt,name=raw_author,json=rawAuthor" json:"raw_author,omitempty"`
-	Author               string   `protobuf:"bytes,3,opt,name=author" json:"author,omitempty"`
-	RawNode              string   `protobuf:"bytes,4,opt,name=raw_node,json=rawNode" json:"raw_node,omitempty"`
-	Branch               string   `protobuf:"bytes,5,opt,name=branch" json:"branch,omitempty"`
+	Node                 string   `protobuf:"bytes,1,opt,name=node,proto3" json:"node,omitempty"`
+	RawAuthor            string   `protobuf:"bytes,2,opt,name=raw_author,json=rawAuthor,proto3" json:"raw_author,omitempty"`
+	Author               string   `protobuf:"bytes,3,opt,name=author,proto3" json:"author,omitempty"`
+	RawNode              string   `protobuf:"bytes,4,opt,name=raw_node,json=rawNode,proto3" json:"raw_node,omitempty"`
+	Branch               string   `protobuf:"bytes,5,opt,name=branch,proto3" json:"branch,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -535,10 +535,10 @@ func (m *ChangeSetV1) GetBranch() string {
 }
 
 type PaginatedRepoBranches struct {
-	Pagelen              float64   `protobuf:"fixed64,1,opt,name=pagelen" json:"pagelen,omitempty"`
-	Page                 float64   `protobuf:"fixed64,2,opt,name=page" json:"page,omitempty"`
-	Next                 string    `protobuf:"bytes,3,opt,name=next" json:"next,omitempty"`
-	Values               []*Branch `protobuf:"bytes,4,rep,name=values" json:"values,omitempty"`
+	Pagelen              float64   `protobuf:"fixed64,1,opt,name=pagelen,proto3" json:"pagelen,omitempty"`
+	Page                 float64   `protobuf:"fixed64,2,opt,name=page,proto3" json:"page,omitempty"`
+	Next                 string    `protobuf:"bytes,3,opt,name=next,proto3" json:"next,omitempty"`
+	Values               []*Branch `protobuf:"bytes,4,rep,name=values,proto3" json:"values,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}  `json:"-"`
 	XXX_unrecognized     []byte    `json:"-"`
 	XXX_sizecache        int32     `json:"-"`
@@ -597,8 +597,8 @@ func (m *PaginatedRepoBranches) GetValues() []*Branch {
 }
 
 type Branch struct {
-	Name                 string         `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
-	Target               *Branch_Target `protobuf:"bytes,2,opt,name=target" json:"target,omitempty"`
+	Name                 string         `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Target               *Branch_Target `protobuf:"bytes,2,opt,name=target,proto3" json:"target,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}       `json:"-"`
 	XXX_unrecognized     []byte         `json:"-"`
 	XXX_sizecache        int32          `json:"-"`
@@ -643,11 +643,11 @@ func (m *Branch) GetTarget() *Branch_Target {
 }
 
 type Branch_Target struct {
-	Hash                 string               `protobuf:"bytes,1,opt,name=hash" json:"hash,omitempty"`
-	Author               *Author              `protobuf:"bytes,2,opt,name=author" json:"author,omitempty"`
-	Date                 *timestamp.Timestamp `protobuf:"bytes,3,opt,name=date" json:"date,omitempty"`
-	Message              string               `protobuf:"bytes,4,opt,name=message" json:"message,omitempty"`
-	Type                 string               `protobuf:"bytes,5,opt,name=type" json:"type,omitempty"`
+	Hash                 string               `protobuf:"bytes,1,opt,name=hash,proto3" json:"hash,omitempty"`
+	Author               *Author              `protobuf:"bytes,2,opt,name=author,proto3" json:"author,omitempty"`
+	Date                 *timestamp.Timestamp `protobuf:"bytes,3,opt,name=date,proto3" json:"date,omitempty"`
+	Message              string               `protobuf:"bytes,4,opt,name=message,proto3" json:"message,omitempty"`
+	Type                 string               `protobuf:"bytes,5,opt,name=type,proto3" json:"type,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}             `json:"-"`
 	XXX_unrecognized     []byte               `json:"-"`
 	XXX_sizecache        int32                `json:"-"`

--- a/models/bitbucket/pb/webhook.pb.go
+++ b/models/bitbucket/pb/webhook.pb.go
@@ -21,9 +21,9 @@ const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
 // https://confluence.atlassian.com/bitbucket/event-payloads-740262817.html#EventPayloads-Push
 type RepoPush struct {
-	Actor                *Owner               `protobuf:"bytes,1,opt,name=actor" json:"actor,omitempty"`
-	Repository           *Repository          `protobuf:"bytes,2,opt,name=repository" json:"repository,omitempty"`
-	Push                 *RepoPush_PushDetail `protobuf:"bytes,3,opt,name=push" json:"push,omitempty"`
+	Actor                *Owner               `protobuf:"bytes,1,opt,name=actor,proto3" json:"actor,omitempty"`
+	Repository           *Repository          `protobuf:"bytes,2,opt,name=repository,proto3" json:"repository,omitempty"`
+	Push                 *RepoPush_PushDetail `protobuf:"bytes,3,opt,name=push,proto3" json:"push,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}             `json:"-"`
 	XXX_unrecognized     []byte               `json:"-"`
 	XXX_sizecache        int32                `json:"-"`
@@ -75,7 +75,7 @@ func (m *RepoPush) GetPush() *RepoPush_PushDetail {
 }
 
 type RepoPush_PushDetail struct {
-	Changes              []*Changeset `protobuf:"bytes,1,rep,name=changes" json:"changes,omitempty"`
+	Changes              []*Changeset `protobuf:"bytes,1,rep,name=changes,proto3" json:"changes,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}     `json:"-"`
 	XXX_unrecognized     []byte       `json:"-"`
 	XXX_sizecache        int32        `json:"-"`
@@ -114,9 +114,9 @@ func (m *RepoPush_PushDetail) GetChanges() []*Changeset {
 
 // same for created and updated
 type PullRequest struct {
-	Actor                *Owner             `protobuf:"bytes,1,opt,name=actor" json:"actor,omitempty"`
-	Pullrequest          *PullRequestEntity `protobuf:"bytes,2,opt,name=pullrequest" json:"pullrequest,omitempty"`
-	Repository           *Repository        `protobuf:"bytes,3,opt,name=repository" json:"repository,omitempty"`
+	Actor                *Owner             `protobuf:"bytes,1,opt,name=actor,proto3" json:"actor,omitempty"`
+	Pullrequest          *PullRequestEntity `protobuf:"bytes,2,opt,name=pullrequest,proto3" json:"pullrequest,omitempty"`
+	Repository           *Repository        `protobuf:"bytes,3,opt,name=repository,proto3" json:"repository,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}           `json:"-"`
 	XXX_unrecognized     []byte             `json:"-"`
 	XXX_sizecache        int32              `json:"-"`
@@ -169,10 +169,10 @@ func (m *PullRequest) GetRepository() *Repository {
 
 // approved adds timestamp and approving owner's info
 type PullRequestApproved struct {
-	Actor                *Owner                      `protobuf:"bytes,1,opt,name=actor" json:"actor,omitempty"`
-	Pullrequest          *PullRequestEntity          `protobuf:"bytes,2,opt,name=pullrequest" json:"pullrequest,omitempty"`
-	Repository           *Repository                 `protobuf:"bytes,3,opt,name=repository" json:"repository,omitempty"`
-	Approval             *PullRequestApprovedApprove `protobuf:"bytes,4,opt,name=approval" json:"approval,omitempty"`
+	Actor                *Owner                      `protobuf:"bytes,1,opt,name=actor,proto3" json:"actor,omitempty"`
+	Pullrequest          *PullRequestEntity          `protobuf:"bytes,2,opt,name=pullrequest,proto3" json:"pullrequest,omitempty"`
+	Repository           *Repository                 `protobuf:"bytes,3,opt,name=repository,proto3" json:"repository,omitempty"`
+	Approval             *PullRequestApprovedApprove `protobuf:"bytes,4,opt,name=approval,proto3" json:"approval,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                    `json:"-"`
 	XXX_unrecognized     []byte                      `json:"-"`
 	XXX_sizecache        int32                       `json:"-"`
@@ -231,8 +231,8 @@ func (m *PullRequestApproved) GetApproval() *PullRequestApprovedApprove {
 }
 
 type PullRequestApprovedApprove struct {
-	Date                 *timestamp.Timestamp `protobuf:"bytes,1,opt,name=date" json:"date,omitempty"`
-	User                 *Owner               `protobuf:"bytes,2,opt,name=user" json:"user,omitempty"`
+	Date                 *timestamp.Timestamp `protobuf:"bytes,1,opt,name=date,proto3" json:"date,omitempty"`
+	User                 *Owner               `protobuf:"bytes,2,opt,name=user,proto3" json:"user,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}             `json:"-"`
 	XXX_unrecognized     []byte               `json:"-"`
 	XXX_sizecache        int32                `json:"-"`
@@ -277,10 +277,10 @@ func (m *PullRequestApprovedApprove) GetUser() *Owner {
 }
 
 type CreateWebhook struct {
-	Description          string   `protobuf:"bytes,1,opt,name=description" json:"description,omitempty"`
-	Url                  string   `protobuf:"bytes,2,opt,name=url" json:"url,omitempty"`
-	Active               bool     `protobuf:"varint,3,opt,name=active" json:"active,omitempty"`
-	Events               []string `protobuf:"bytes,4,rep,name=events" json:"events,omitempty"`
+	Description          string   `protobuf:"bytes,1,opt,name=description,proto3" json:"description,omitempty"`
+	Url                  string   `protobuf:"bytes,2,opt,name=url,proto3" json:"url,omitempty"`
+	Active               bool     `protobuf:"varint,3,opt,name=active,proto3" json:"active,omitempty"`
+	Events               []string `protobuf:"bytes,4,rep,name=events,proto3" json:"events,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -339,11 +339,11 @@ func (m *CreateWebhook) GetEvents() []string {
 }
 
 type GetWebhooks struct {
-	Pagelen              float64     `protobuf:"fixed64,1,opt,name=pagelen" json:"pagelen,omitempty"`
-	Page                 float64     `protobuf:"fixed64,2,opt,name=page" json:"page,omitempty"`
-	Size                 float64     `protobuf:"fixed64,3,opt,name=size" json:"size,omitempty"`
-	Values               []*Webhooks `protobuf:"bytes,4,rep,name=values" json:"values,omitempty"`
-	Next                 string      `protobuf:"bytes,5,opt,name=next" json:"next,omitempty"`
+	Pagelen              float64     `protobuf:"fixed64,1,opt,name=pagelen,proto3" json:"pagelen,omitempty"`
+	Page                 float64     `protobuf:"fixed64,2,opt,name=page,proto3" json:"page,omitempty"`
+	Size                 float64     `protobuf:"fixed64,3,opt,name=size,proto3" json:"size,omitempty"`
+	Values               []*Webhooks `protobuf:"bytes,4,rep,name=values,proto3" json:"values,omitempty"`
+	Next                 string      `protobuf:"bytes,5,opt,name=next,proto3" json:"next,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}    `json:"-"`
 	XXX_unrecognized     []byte      `json:"-"`
 	XXX_sizecache        int32       `json:"-"`
@@ -409,11 +409,11 @@ func (m *GetWebhooks) GetNext() string {
 }
 
 type Webhooks struct {
-	Description          string               `protobuf:"bytes,1,opt,name=description" json:"description,omitempty"`
-	Links                *Links               `protobuf:"bytes,2,opt,name=links" json:"links,omitempty"`
-	Url                  string               `protobuf:"bytes,3,opt,name=url" json:"url,omitempty"`
-	CreatedAt            *timestamp.Timestamp `protobuf:"bytes,4,opt,name=createdAt,json=created_at" json:"createdAt,omitempty"`
-	Active               bool                 `protobuf:"varint,5,opt,name=active" json:"active,omitempty"`
+	Description          string               `protobuf:"bytes,1,opt,name=description,proto3" json:"description,omitempty"`
+	Links                *Links               `protobuf:"bytes,2,opt,name=links,proto3" json:"links,omitempty"`
+	Url                  string               `protobuf:"bytes,3,opt,name=url,proto3" json:"url,omitempty"`
+	CreatedAt            *timestamp.Timestamp `protobuf:"bytes,4,opt,name=createdAt,json=created_at,proto3" json:"createdAt,omitempty"`
+	Active               bool                 `protobuf:"varint,5,opt,name=active,proto3" json:"active,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}             `json:"-"`
 	XXX_unrecognized     []byte               `json:"-"`
 	XXX_sizecache        int32                `json:"-"`

--- a/models/creds.proto
+++ b/models/creds.proto
@@ -120,11 +120,11 @@ message K8SCreds {
     string acctName = 1;
     // k8scontents is the contents of the kubeconfig file
     string k8sContents = 2;
-    // identifier in K8s creds is currently irrelevant, as there can only be one per account
+    // identifier in K8s creds, typically the name of the cluster, as expected use case is one config per cluster
     string identifier = 3;
     // @inject_tag: yaml:"subType"
     // there is currently only one subtype for k8SCreds, and it is KUBECONF
-    SubCredType subType = 5;
+    SubCredType subType = 6;
 
 }
 

--- a/models/pb/build.pb.go
+++ b/models/pb/build.pb.go
@@ -45,17 +45,17 @@ func (StageResultVal) EnumDescriptor() ([]byte, []int) {
 type BuildConfig struct {
 	// either image or machineTag is required
 	// image is the docker image to run the build in
-	Image string `protobuf:"bytes,1,opt,name=image" json:"image,omitempty"`
+	Image string `protobuf:"bytes,1,opt,name=image,proto3" json:"image,omitempty"`
 	// machineTag is the
 	// @inject_tag: yaml:"machineTag"
-	MachineTag string `protobuf:"bytes,9,opt,name=machineTag" json:"machineTag,omitempty" yaml:"machineTag"`
+	MachineTag string `protobuf:"bytes,9,opt,name=machineTag,proto3" json:"machineTag,omitempty" yaml:"machineTag"`
 	// @inject_tag: yaml:"buildTool"
-	BuildTool            string         `protobuf:"bytes,2,opt,name=buildTool" json:"buildTool,omitempty" yaml:"buildTool"`
-	Packages             []string       `protobuf:"bytes,3,rep,name=packages" json:"packages,omitempty"`
-	Branches             []string       `protobuf:"bytes,4,rep,name=branches" json:"branches,omitempty"`
-	Env                  []string       `protobuf:"bytes,5,rep,name=env" json:"env,omitempty"`
-	Stages               []*Stage       `protobuf:"bytes,7,rep,name=stages" json:"stages,omitempty"`
-	Notify               *Notifications `protobuf:"bytes,8,opt,name=notify" json:"notify,omitempty"`
+	BuildTool            string         `protobuf:"bytes,2,opt,name=buildTool,proto3" json:"buildTool,omitempty" yaml:"buildTool"`
+	Packages             []string       `protobuf:"bytes,3,rep,name=packages,proto3" json:"packages,omitempty"`
+	Branches             []string       `protobuf:"bytes,4,rep,name=branches,proto3" json:"branches,omitempty"`
+	Env                  []string       `protobuf:"bytes,5,rep,name=env,proto3" json:"env,omitempty"`
+	Stages               []*Stage       `protobuf:"bytes,7,rep,name=stages,proto3" json:"stages,omitempty"`
+	Notify               *Notifications `protobuf:"bytes,8,opt,name=notify,proto3" json:"notify,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}       `json:"-"`
 	XXX_unrecognized     []byte         `json:"-"`
 	XXX_sizecache        int32          `json:"-"`
@@ -142,11 +142,11 @@ func (m *BuildConfig) GetNotify() *Notifications {
 }
 
 type Stage struct {
-	Env    []string `protobuf:"bytes,1,rep,name=env" json:"env,omitempty"`
-	Script []string `protobuf:"bytes,2,rep,name=script" json:"script,omitempty"`
-	Name   string   `protobuf:"bytes,3,opt,name=name" json:"name,omitempty"`
+	Env    []string `protobuf:"bytes,1,rep,name=env,proto3" json:"env,omitempty"`
+	Script []string `protobuf:"bytes,2,rep,name=script,proto3" json:"script,omitempty"`
+	Name   string   `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
 	// @inject_tag: yaml:"trigger"
-	Trigger              *Triggers `protobuf:"bytes,4,opt,name=trigger" json:"trigger,omitempty" yaml:"trigger"`
+	Trigger              *Triggers `protobuf:"bytes,4,opt,name=trigger,proto3" json:"trigger,omitempty" yaml:"trigger"`
 	XXX_NoUnkeyedLiteral struct{}  `json:"-"`
 	XXX_unrecognized     []byte    `json:"-"`
 	XXX_sizecache        int32     `json:"-"`
@@ -206,7 +206,7 @@ func (m *Stage) GetTrigger() *Triggers {
 
 // todo: move to a new notifications.proto?
 type Notifications struct {
-	Slack                *Slack   `protobuf:"bytes,1,opt,name=slack" json:"slack,omitempty"`
+	Slack                *Slack   `protobuf:"bytes,1,opt,name=slack,proto3" json:"slack,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -246,11 +246,11 @@ func (m *Notifications) GetSlack() *Slack {
 // todo: move to a new notifications.proto?
 type Slack struct {
 	// channel is which channel to post to. if empty, will be default channel set up by person who created url
-	Channel string `protobuf:"bytes,1,opt,name=channel" json:"channel,omitempty"`
+	Channel string `protobuf:"bytes,1,opt,name=channel,proto3" json:"channel,omitempty"`
 	//  identifier attached to url uploaded via `ocelot creds slack add`
-	Identifier string `protobuf:"bytes,2,opt,name=identifier" json:"identifier,omitempty"`
+	Identifier string `protobuf:"bytes,2,opt,name=identifier,proto3" json:"identifier,omitempty"`
 	// on is what type of event to trigger a webhook on can be both PASS and FAIL
-	On                   []StageResultVal `protobuf:"varint,3,rep,packed,name=on,enum=models.StageResultVal" json:"on,omitempty"`
+	On                   []StageResultVal `protobuf:"varint,3,rep,packed,name=on,proto3,enum=models.StageResultVal" json:"on,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}         `json:"-"`
 	XXX_unrecognized     []byte           `json:"-"`
 	XXX_sizecache        int32            `json:"-"`
@@ -302,10 +302,10 @@ func (m *Slack) GetOn() []StageResultVal {
 }
 
 type Result struct {
-	Stage                string         `protobuf:"bytes,1,opt,name=stage" json:"stage,omitempty"`
-	Status               StageResultVal `protobuf:"varint,2,opt,name=status,enum=models.StageResultVal" json:"status,omitempty"`
-	Error                string         `protobuf:"bytes,3,opt,name=error" json:"error,omitempty"`
-	Messages             []string       `protobuf:"bytes,4,rep,name=messages" json:"messages,omitempty"`
+	Stage                string         `protobuf:"bytes,1,opt,name=stage,proto3" json:"stage,omitempty"`
+	Status               StageResultVal `protobuf:"varint,2,opt,name=status,proto3,enum=models.StageResultVal" json:"status,omitempty"`
+	Error                string         `protobuf:"bytes,3,opt,name=error,proto3" json:"error,omitempty"`
+	Messages             []string       `protobuf:"bytes,4,rep,name=messages,proto3" json:"messages,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}       `json:"-"`
 	XXX_unrecognized     []byte         `json:"-"`
 	XXX_sizecache        int32          `json:"-"`
@@ -364,7 +364,7 @@ func (m *Result) GetMessages() []string {
 }
 
 type Triggers struct {
-	Branches             []string `protobuf:"bytes,1,rep,name=branches" json:"branches,omitempty"`
+	Branches             []string `protobuf:"bytes,1,rep,name=branches,proto3" json:"branches,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -402,14 +402,14 @@ func (m *Triggers) GetBranches() []string {
 }
 
 type WerkerTask struct {
-	VaultToken           string       `protobuf:"bytes,1,opt,name=vaultToken" json:"vaultToken,omitempty"`
-	CheckoutHash         string       `protobuf:"bytes,2,opt,name=checkoutHash" json:"checkoutHash,omitempty"`
-	BuildConf            *BuildConfig `protobuf:"bytes,3,opt,name=buildConf" json:"buildConf,omitempty"`
-	VcsToken             string       `protobuf:"bytes,4,opt,name=vcsToken" json:"vcsToken,omitempty"`
-	VcsType              SubCredType  `protobuf:"varint,9,opt,name=vcsType,enum=models.SubCredType" json:"vcsType,omitempty"`
-	FullName             string       `protobuf:"bytes,6,opt,name=fullName" json:"fullName,omitempty"`
-	Id                   int64        `protobuf:"varint,7,opt,name=id" json:"id,omitempty"`
-	Branch               string       `protobuf:"bytes,8,opt,name=branch" json:"branch,omitempty"`
+	VaultToken           string       `protobuf:"bytes,1,opt,name=vaultToken,proto3" json:"vaultToken,omitempty"`
+	CheckoutHash         string       `protobuf:"bytes,2,opt,name=checkoutHash,proto3" json:"checkoutHash,omitempty"`
+	BuildConf            *BuildConfig `protobuf:"bytes,3,opt,name=buildConf,proto3" json:"buildConf,omitempty"`
+	VcsToken             string       `protobuf:"bytes,4,opt,name=vcsToken,proto3" json:"vcsToken,omitempty"`
+	VcsType              SubCredType  `protobuf:"varint,9,opt,name=vcsType,proto3,enum=models.SubCredType" json:"vcsType,omitempty"`
+	FullName             string       `protobuf:"bytes,6,opt,name=fullName,proto3" json:"fullName,omitempty"`
+	Id                   int64        `protobuf:"varint,7,opt,name=id,proto3" json:"id,omitempty"`
+	Branch               string       `protobuf:"bytes,8,opt,name=branch,proto3" json:"branch,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}     `json:"-"`
 	XXX_unrecognized     []byte       `json:"-"`
 	XXX_sizecache        int32        `json:"-"`

--- a/models/pb/creds.pb.go
+++ b/models/pb/creds.pb.go
@@ -59,7 +59,7 @@ func (x CredType) String() string {
 	return proto.EnumName(CredType_name, int32(x))
 }
 func (CredType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_creds_4af25941be456e6c, []int{0}
+	return fileDescriptor_creds_69d9d3ee77321fcd, []int{0}
 }
 
 type SubCredType int32
@@ -106,16 +106,16 @@ func (x SubCredType) String() string {
 	return proto.EnumName(SubCredType_name, int32(x))
 }
 func (SubCredType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_creds_4af25941be456e6c, []int{1}
+	return fileDescriptor_creds_69d9d3ee77321fcd, []int{1}
 }
 
 type AllCredsWrapper struct {
 	// All repository credentials for integrations
 	// @inject_tag: yaml:"repoCreds"
-	RepoCreds *RepoCredWrapper `protobuf:"bytes,1,opt,name=repoCreds" json:"repoCreds,omitempty" yaml:"repoCreds"`
+	RepoCreds *RepoCredWrapper `protobuf:"bytes,1,opt,name=repoCreds,proto3" json:"repoCreds,omitempty" yaml:"repoCreds"`
 	// All VCS credentials for building
 	// @inject_tag: yaml:"vcsCreds"
-	VcsCreds             *CredWrapper `protobuf:"bytes,3,opt,name=vcsCreds" json:"vcsCreds,omitempty" yaml:"vcsCreds"`
+	VcsCreds             *CredWrapper `protobuf:"bytes,3,opt,name=vcsCreds,proto3" json:"vcsCreds,omitempty" yaml:"vcsCreds"`
 	XXX_NoUnkeyedLiteral struct{}     `json:"-"`
 	XXX_unrecognized     []byte       `json:"-"`
 	XXX_sizecache        int32        `json:"-"`
@@ -125,7 +125,7 @@ func (m *AllCredsWrapper) Reset()         { *m = AllCredsWrapper{} }
 func (m *AllCredsWrapper) String() string { return proto.CompactTextString(m) }
 func (*AllCredsWrapper) ProtoMessage()    {}
 func (*AllCredsWrapper) Descriptor() ([]byte, []int) {
-	return fileDescriptor_creds_4af25941be456e6c, []int{0}
+	return fileDescriptor_creds_69d9d3ee77321fcd, []int{0}
 }
 func (m *AllCredsWrapper) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_AllCredsWrapper.Unmarshal(m, b)
@@ -161,7 +161,7 @@ func (m *AllCredsWrapper) GetVcsCreds() *CredWrapper {
 
 // just a container for a list of VCSCreds
 type CredWrapper struct {
-	Vcs                  []*VCSCreds `protobuf:"bytes,2,rep,name=vcs" json:"vcs,omitempty"`
+	Vcs                  []*VCSCreds `protobuf:"bytes,2,rep,name=vcs,proto3" json:"vcs,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}    `json:"-"`
 	XXX_unrecognized     []byte      `json:"-"`
 	XXX_sizecache        int32       `json:"-"`
@@ -171,7 +171,7 @@ func (m *CredWrapper) Reset()         { *m = CredWrapper{} }
 func (m *CredWrapper) String() string { return proto.CompactTextString(m) }
 func (*CredWrapper) ProtoMessage()    {}
 func (*CredWrapper) Descriptor() ([]byte, []int) {
-	return fileDescriptor_creds_4af25941be456e6c, []int{1}
+	return fileDescriptor_creds_69d9d3ee77321fcd, []int{1}
 }
 func (m *CredWrapper) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CredWrapper.Unmarshal(m, b)
@@ -200,13 +200,13 @@ func (m *CredWrapper) GetVcs() []*VCSCreds {
 
 type SSHKeyWrapper struct {
 	// account name to associate ssh key with
-	AcctName string `protobuf:"bytes,1,opt,name=acctName" json:"acctName,omitempty"`
+	AcctName string `protobuf:"bytes,1,opt,name=acctName,proto3" json:"acctName,omitempty"`
 	// the contents of the private key
 	PrivateKey []byte `protobuf:"bytes,2,opt,name=privateKey,proto3" json:"privateKey,omitempty"`
 	// There is only one subType taht is valid for SSHKeyWrapper, and it is SSHKEY
-	SubType SubCredType `protobuf:"varint,10,opt,name=subType,enum=models.SubCredType" json:"subType,omitempty"`
+	SubType SubCredType `protobuf:"varint,10,opt,name=subType,proto3,enum=models.SubCredType" json:"subType,omitempty"`
 	// identifier is the unique identifier for when an ssh key is not associated with a VCS account.
-	Identifier           string   `protobuf:"bytes,11,opt,name=identifier" json:"identifier,omitempty"`
+	Identifier           string   `protobuf:"bytes,11,opt,name=identifier,proto3" json:"identifier,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -216,7 +216,7 @@ func (m *SSHKeyWrapper) Reset()         { *m = SSHKeyWrapper{} }
 func (m *SSHKeyWrapper) String() string { return proto.CompactTextString(m) }
 func (*SSHKeyWrapper) ProtoMessage()    {}
 func (*SSHKeyWrapper) Descriptor() ([]byte, []int) {
-	return fileDescriptor_creds_4af25941be456e6c, []int{2}
+	return fileDescriptor_creds_69d9d3ee77321fcd, []int{2}
 }
 func (m *SSHKeyWrapper) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SSHKeyWrapper.Unmarshal(m, b)
@@ -265,7 +265,7 @@ func (m *SSHKeyWrapper) GetIdentifier() string {
 }
 
 type SSHWrap struct {
-	Keys                 []*SSHKeyWrapper `protobuf:"bytes,1,rep,name=keys" json:"keys,omitempty"`
+	Keys                 []*SSHKeyWrapper `protobuf:"bytes,1,rep,name=keys,proto3" json:"keys,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}         `json:"-"`
 	XXX_unrecognized     []byte           `json:"-"`
 	XXX_sizecache        int32            `json:"-"`
@@ -275,7 +275,7 @@ func (m *SSHWrap) Reset()         { *m = SSHWrap{} }
 func (m *SSHWrap) String() string { return proto.CompactTextString(m) }
 func (*SSHWrap) ProtoMessage()    {}
 func (*SSHWrap) Descriptor() ([]byte, []int) {
-	return fileDescriptor_creds_4af25941be456e6c, []int{3}
+	return fileDescriptor_creds_69d9d3ee77321fcd, []int{3}
 }
 func (m *SSHWrap) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SSHWrap.Unmarshal(m, b)
@@ -305,24 +305,24 @@ func (m *SSHWrap) GetKeys() []*SSHKeyWrapper {
 type VCSCreds struct {
 	// clientId is generated by creating an oAuth consumer in bitbucket. it is required to generate tokens.
 	// @inject_tag: yaml:"clientId"
-	ClientId string `protobuf:"bytes,1,opt,name=clientId" json:"clientId,omitempty" yaml:"clientId"`
+	ClientId string `protobuf:"bytes,1,opt,name=clientId,proto3" json:"clientId,omitempty" yaml:"clientId"`
 	// clientSecret is generated by creating an oAuth consumer in bitbucket. it is required to generate tokens.
 	// @inject_tag: yaml:"clientSecret"
-	ClientSecret string `protobuf:"bytes,2,opt,name=clientSecret" json:"clientSecret,omitempty" yaml:"clientSecret"`
+	ClientSecret string `protobuf:"bytes,2,opt,name=clientSecret,proto3" json:"clientSecret,omitempty" yaml:"clientSecret"`
 	// identifier is the name the user calls teh credential set
-	Identifier string `protobuf:"bytes,8,opt,name=identifier" json:"identifier,omitempty"`
+	Identifier string `protobuf:"bytes,8,opt,name=identifier,proto3" json:"identifier,omitempty"`
 	// tokenUrl is the url at which to retrieve the token
 	// @inject_tag: yaml:"tokenURL"
-	TokenURL string `protobuf:"bytes,3,opt,name=tokenURL" json:"tokenURL,omitempty" yaml:"tokenURL"`
+	TokenURL string `protobuf:"bytes,3,opt,name=tokenURL,proto3" json:"tokenURL,omitempty" yaml:"tokenURL"`
 	// @inject_tag: yaml:"acctName"
 	// acctName is the account to associate the VCSCred with. Must be the account name of the owner of the repository they wish to track (ie level11consulting)
-	AcctName string `protobuf:"bytes,4,opt,name=acctName" json:"acctName,omitempty" yaml:"acctName"`
+	AcctName string `protobuf:"bytes,4,opt,name=acctName,proto3" json:"acctName,omitempty" yaml:"acctName"`
 	// just a string that says whether or not there is an ssh key on file
 	// @inject_tag: yaml:"sshFileLoc"
-	SshFileLoc string `protobuf:"bytes,6,opt,name=sshFileLoc" json:"sshFileLoc,omitempty" yaml:"sshFileLoc"`
+	SshFileLoc string `protobuf:"bytes,6,opt,name=sshFileLoc,proto3" json:"sshFileLoc,omitempty" yaml:"sshFileLoc"`
 	// there is only one subtype that is valid for VCS creds at this time, and it is BITBUCKET
 	// @inject_tag: yaml:"subType"
-	SubType              SubCredType `protobuf:"varint,10,opt,name=subType,enum=models.SubCredType" json:"subType,omitempty" yaml:"subType"`
+	SubType              SubCredType `protobuf:"varint,10,opt,name=subType,proto3,enum=models.SubCredType" json:"subType,omitempty" yaml:"subType"`
 	XXX_NoUnkeyedLiteral struct{}    `json:"-"`
 	XXX_unrecognized     []byte      `json:"-"`
 	XXX_sizecache        int32       `json:"-"`
@@ -332,7 +332,7 @@ func (m *VCSCreds) Reset()         { *m = VCSCreds{} }
 func (m *VCSCreds) String() string { return proto.CompactTextString(m) }
 func (*VCSCreds) ProtoMessage()    {}
 func (*VCSCreds) Descriptor() ([]byte, []int) {
-	return fileDescriptor_creds_4af25941be456e6c, []int{4}
+	return fileDescriptor_creds_69d9d3ee77321fcd, []int{4}
 }
 func (m *VCSCreds) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_VCSCreds.Unmarshal(m, b)
@@ -403,7 +403,7 @@ func (m *VCSCreds) GetSubType() SubCredType {
 
 // container for list of repo creds
 type RepoCredWrapper struct {
-	Repo                 []*RepoCreds `protobuf:"bytes,3,rep,name=repo" json:"repo,omitempty"`
+	Repo                 []*RepoCreds `protobuf:"bytes,3,rep,name=repo,proto3" json:"repo,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}     `json:"-"`
 	XXX_unrecognized     []byte       `json:"-"`
 	XXX_sizecache        int32        `json:"-"`
@@ -413,7 +413,7 @@ func (m *RepoCredWrapper) Reset()         { *m = RepoCredWrapper{} }
 func (m *RepoCredWrapper) String() string { return proto.CompactTextString(m) }
 func (*RepoCredWrapper) ProtoMessage()    {}
 func (*RepoCredWrapper) Descriptor() ([]byte, []int) {
-	return fileDescriptor_creds_4af25941be456e6c, []int{5}
+	return fileDescriptor_creds_69d9d3ee77321fcd, []int{5}
 }
 func (m *RepoCredWrapper) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RepoCredWrapper.Unmarshal(m, b)
@@ -442,20 +442,20 @@ func (m *RepoCredWrapper) GetRepo() []*RepoCreds {
 
 type RepoCreds struct {
 	// username of repository
-	Username string `protobuf:"bytes,1,opt,name=username" json:"username,omitempty"`
+	Username string `protobuf:"bytes,1,opt,name=username,proto3" json:"username,omitempty"`
 	// password of repository
-	Password string `protobuf:"bytes,2,opt,name=password" json:"password,omitempty"`
+	Password string `protobuf:"bytes,2,opt,name=password,proto3" json:"password,omitempty"`
 	// @inject_tag: yaml:"repoUrl"
 	// repoUrl is the url that is associated with that repository, for example hub.docker.io
-	RepoUrl string `protobuf:"bytes,6,opt,name=repoUrl" json:"repoUrl,omitempty" yaml:"repoUrl"`
+	RepoUrl string `protobuf:"bytes,6,opt,name=repoUrl,proto3" json:"repoUrl,omitempty" yaml:"repoUrl"`
 	// identifier is the unique identifier that is associated with this acctName
-	Identifier string `protobuf:"bytes,8,opt,name=identifier" json:"identifier,omitempty"`
+	Identifier string `protobuf:"bytes,8,opt,name=identifier,proto3" json:"identifier,omitempty"`
 	// @inject_tag: yaml:"acctName"
 	// account name (same as from vcs)
-	AcctName string `protobuf:"bytes,4,opt,name=acctName" json:"acctName,omitempty" yaml:"acctName"`
+	AcctName string `protobuf:"bytes,4,opt,name=acctName,proto3" json:"acctName,omitempty" yaml:"acctName"`
 	// @inject_tag: yaml:"subType"
 	// there are two subtypes that are valid for RepoCreds: DOCKER, NEXUS
-	SubType              SubCredType `protobuf:"varint,10,opt,name=subType,enum=models.SubCredType" json:"subType,omitempty" yaml:"subType"`
+	SubType              SubCredType `protobuf:"varint,10,opt,name=subType,proto3,enum=models.SubCredType" json:"subType,omitempty" yaml:"subType"`
 	XXX_NoUnkeyedLiteral struct{}    `json:"-"`
 	XXX_unrecognized     []byte      `json:"-"`
 	XXX_sizecache        int32       `json:"-"`
@@ -465,7 +465,7 @@ func (m *RepoCreds) Reset()         { *m = RepoCreds{} }
 func (m *RepoCreds) String() string { return proto.CompactTextString(m) }
 func (*RepoCreds) ProtoMessage()    {}
 func (*RepoCreds) Descriptor() ([]byte, []int) {
-	return fileDescriptor_creds_4af25941be456e6c, []int{6}
+	return fileDescriptor_creds_69d9d3ee77321fcd, []int{6}
 }
 func (m *RepoCreds) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RepoCreds.Unmarshal(m, b)
@@ -529,14 +529,14 @@ func (m *RepoCreds) GetSubType() SubCredType {
 
 type K8SCreds struct {
 	// account name to associate this credential with
-	AcctName string `protobuf:"bytes,1,opt,name=acctName" json:"acctName,omitempty"`
+	AcctName string `protobuf:"bytes,1,opt,name=acctName,proto3" json:"acctName,omitempty"`
 	// k8scontents is the contents of the kubeconfig file
-	K8SContents string `protobuf:"bytes,2,opt,name=k8sContents" json:"k8sContents,omitempty"`
-	// identifier in K8s creds is currently irrelevant, as there can only be one per account
-	Identifier string `protobuf:"bytes,3,opt,name=identifier" json:"identifier,omitempty"`
+	K8SContents string `protobuf:"bytes,2,opt,name=k8sContents,proto3" json:"k8sContents,omitempty"`
+	// identifier in K8s creds, typically the name of the cluster, as expected use case is one config per cluster
+	Identifier string `protobuf:"bytes,3,opt,name=identifier,proto3" json:"identifier,omitempty"`
 	// @inject_tag: yaml:"subType"
 	// there is currently only one subtype for k8SCreds, and it is KUBECONF
-	SubType              SubCredType `protobuf:"varint,5,opt,name=subType,enum=models.SubCredType" json:"subType,omitempty" yaml:"subType"`
+	SubType              SubCredType `protobuf:"varint,6,opt,name=subType,proto3,enum=models.SubCredType" json:"subType,omitempty" yaml:"subType"`
 	XXX_NoUnkeyedLiteral struct{}    `json:"-"`
 	XXX_unrecognized     []byte      `json:"-"`
 	XXX_sizecache        int32       `json:"-"`
@@ -546,7 +546,7 @@ func (m *K8SCreds) Reset()         { *m = K8SCreds{} }
 func (m *K8SCreds) String() string { return proto.CompactTextString(m) }
 func (*K8SCreds) ProtoMessage()    {}
 func (*K8SCreds) Descriptor() ([]byte, []int) {
-	return fileDescriptor_creds_4af25941be456e6c, []int{7}
+	return fileDescriptor_creds_69d9d3ee77321fcd, []int{7}
 }
 func (m *K8SCreds) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_K8SCreds.Unmarshal(m, b)
@@ -595,7 +595,7 @@ func (m *K8SCreds) GetSubType() SubCredType {
 }
 
 type K8SCredsWrapper struct {
-	K8SCreds             []*K8SCreds `protobuf:"bytes,2,rep,name=K8SCreds" json:"K8SCreds,omitempty"`
+	K8SCreds             []*K8SCreds `protobuf:"bytes,2,rep,name=K8SCreds,proto3" json:"K8SCreds,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}    `json:"-"`
 	XXX_unrecognized     []byte      `json:"-"`
 	XXX_sizecache        int32       `json:"-"`
@@ -605,7 +605,7 @@ func (m *K8SCredsWrapper) Reset()         { *m = K8SCredsWrapper{} }
 func (m *K8SCredsWrapper) String() string { return proto.CompactTextString(m) }
 func (*K8SCredsWrapper) ProtoMessage()    {}
 func (*K8SCredsWrapper) Descriptor() ([]byte, []int) {
-	return fileDescriptor_creds_4af25941be456e6c, []int{8}
+	return fileDescriptor_creds_69d9d3ee77321fcd, []int{8}
 }
 func (m *K8SCredsWrapper) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_K8SCredsWrapper.Unmarshal(m, b)
@@ -634,15 +634,15 @@ func (m *K8SCredsWrapper) GetK8SCreds() []*K8SCreds {
 
 type AppleCreds struct {
 	// account name to associate this credential with
-	AcctName string `protobuf:"bytes,1,opt,name=acctName" json:"acctName,omitempty"`
+	AcctName string `protobuf:"bytes,1,opt,name=acctName,proto3" json:"acctName,omitempty"`
 	// identifier in dev profile creds is currently irrelevant, as there can only be one per account
-	Identifier string `protobuf:"bytes,3,opt,name=identifier" json:"identifier,omitempty"`
+	Identifier string `protobuf:"bytes,3,opt,name=identifier,proto3" json:"identifier,omitempty"`
 	// appleSecrets is the zip contents of the apple developer profile that you export in XCode ??
 	AppleSecrets []byte `protobuf:"bytes,2,opt,name=appleSecrets,proto3" json:"appleSecrets,omitempty"`
 	// appleSecretsPassword is the password you set when you export the developer profile
-	AppleSecretsPassword string `protobuf:"bytes,6,opt,name=appleSecretsPassword" json:"appleSecretsPassword,omitempty"`
+	AppleSecretsPassword string `protobuf:"bytes,6,opt,name=appleSecretsPassword,proto3" json:"appleSecretsPassword,omitempty"`
 	// @inject_tag: yaml:"subType"
-	SubType              SubCredType `protobuf:"varint,5,opt,name=subType,enum=models.SubCredType" json:"subType,omitempty" yaml:"subType"`
+	SubType              SubCredType `protobuf:"varint,5,opt,name=subType,proto3,enum=models.SubCredType" json:"subType,omitempty" yaml:"subType"`
 	XXX_NoUnkeyedLiteral struct{}    `json:"-"`
 	XXX_unrecognized     []byte      `json:"-"`
 	XXX_sizecache        int32       `json:"-"`
@@ -652,7 +652,7 @@ func (m *AppleCreds) Reset()         { *m = AppleCreds{} }
 func (m *AppleCreds) String() string { return proto.CompactTextString(m) }
 func (*AppleCreds) ProtoMessage()    {}
 func (*AppleCreds) Descriptor() ([]byte, []int) {
-	return fileDescriptor_creds_4af25941be456e6c, []int{9}
+	return fileDescriptor_creds_69d9d3ee77321fcd, []int{9}
 }
 func (m *AppleCreds) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_AppleCreds.Unmarshal(m, b)
@@ -708,7 +708,7 @@ func (m *AppleCreds) GetSubType() SubCredType {
 }
 
 type AppleCredsWrapper struct {
-	AppleCreds           []*AppleCreds `protobuf:"bytes,1,rep,name=appleCreds" json:"appleCreds,omitempty"`
+	AppleCreds           []*AppleCreds `protobuf:"bytes,1,rep,name=appleCreds,proto3" json:"appleCreds,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
 	XXX_unrecognized     []byte        `json:"-"`
 	XXX_sizecache        int32         `json:"-"`
@@ -718,7 +718,7 @@ func (m *AppleCredsWrapper) Reset()         { *m = AppleCredsWrapper{} }
 func (m *AppleCredsWrapper) String() string { return proto.CompactTextString(m) }
 func (*AppleCredsWrapper) ProtoMessage()    {}
 func (*AppleCredsWrapper) Descriptor() ([]byte, []int) {
-	return fileDescriptor_creds_4af25941be456e6c, []int{10}
+	return fileDescriptor_creds_69d9d3ee77321fcd, []int{10}
 }
 func (m *AppleCredsWrapper) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_AppleCredsWrapper.Unmarshal(m, b)
@@ -746,7 +746,7 @@ func (m *AppleCredsWrapper) GetAppleCreds() []*AppleCreds {
 }
 
 type NotifyWrap struct {
-	Creds                []*NotifyCreds `protobuf:"bytes,1,rep,name=creds" json:"creds,omitempty"`
+	Creds                []*NotifyCreds `protobuf:"bytes,1,rep,name=creds,proto3" json:"creds,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}       `json:"-"`
 	XXX_unrecognized     []byte         `json:"-"`
 	XXX_sizecache        int32          `json:"-"`
@@ -756,7 +756,7 @@ func (m *NotifyWrap) Reset()         { *m = NotifyWrap{} }
 func (m *NotifyWrap) String() string { return proto.CompactTextString(m) }
 func (*NotifyWrap) ProtoMessage()    {}
 func (*NotifyWrap) Descriptor() ([]byte, []int) {
-	return fileDescriptor_creds_4af25941be456e6c, []int{11}
+	return fileDescriptor_creds_69d9d3ee77321fcd, []int{11}
 }
 func (m *NotifyWrap) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NotifyWrap.Unmarshal(m, b)
@@ -785,13 +785,13 @@ func (m *NotifyWrap) GetCreds() []*NotifyCreds {
 
 type NotifyCreds struct {
 	// account name to associate integration cred with
-	AcctName string `protobuf:"bytes,1,opt,name=acctName" json:"acctName,omitempty"`
+	AcctName string `protobuf:"bytes,1,opt,name=acctName,proto3" json:"acctName,omitempty"`
 	// There is currently only one subType that is valid for Integrations, and it is SLACK
-	SubType SubCredType `protobuf:"varint,2,opt,name=subType,enum=models.SubCredType" json:"subType,omitempty"`
+	SubType SubCredType `protobuf:"varint,2,opt,name=subType,proto3,enum=models.SubCredType" json:"subType,omitempty"`
 	// identifier is the unique identifier for the integration
-	Identifier string `protobuf:"bytes,3,opt,name=identifier" json:"identifier,omitempty"`
+	Identifier string `protobuf:"bytes,3,opt,name=identifier,proto3" json:"identifier,omitempty"`
 	// clientSecret is the secret associated with the integration cred
-	ClientSecret         string   `protobuf:"bytes,4,opt,name=clientSecret" json:"clientSecret,omitempty"`
+	ClientSecret         string   `protobuf:"bytes,4,opt,name=clientSecret,proto3" json:"clientSecret,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -801,7 +801,7 @@ func (m *NotifyCreds) Reset()         { *m = NotifyCreds{} }
 func (m *NotifyCreds) String() string { return proto.CompactTextString(m) }
 func (*NotifyCreds) ProtoMessage()    {}
 func (*NotifyCreds) Descriptor() ([]byte, []int) {
-	return fileDescriptor_creds_4af25941be456e6c, []int{12}
+	return fileDescriptor_creds_69d9d3ee77321fcd, []int{12}
 }
 func (m *NotifyCreds) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NotifyCreds.Unmarshal(m, b)
@@ -867,55 +867,55 @@ func init() {
 	proto.RegisterEnum("models.SubCredType", SubCredType_name, SubCredType_value)
 }
 
-func init() { proto.RegisterFile("creds.proto", fileDescriptor_creds_4af25941be456e6c) }
+func init() { proto.RegisterFile("creds.proto", fileDescriptor_creds_69d9d3ee77321fcd) }
 
-var fileDescriptor_creds_4af25941be456e6c = []byte{
-	// 750 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x55, 0xdd, 0x6e, 0xda, 0x4a,
-	0x10, 0x3e, 0xe6, 0xd7, 0x1e, 0x93, 0x64, 0xb3, 0xe7, 0x1c, 0x1d, 0xeb, 0x5c, 0x54, 0xc8, 0x52,
-	0x25, 0x1a, 0xb5, 0xa9, 0x4a, 0x5b, 0x95, 0xbb, 0x0a, 0x1c, 0x13, 0x90, 0x29, 0xa0, 0x35, 0xd0,
-	0x9f, 0x9b, 0x0a, 0xcc, 0x46, 0x45, 0x21, 0xd8, 0xb2, 0x9d, 0x54, 0xbc, 0x43, 0xef, 0x2b, 0x55,
-	0x7d, 0xa0, 0xde, 0xf5, 0x59, 0xfa, 0x06, 0xd5, 0xda, 0x5e, 0x7b, 0x21, 0x49, 0x13, 0xee, 0x98,
-	0x6f, 0xbe, 0x99, 0xfd, 0xe6, 0x9b, 0xf5, 0x02, 0xaa, 0xe3, 0xd3, 0x79, 0x70, 0xec, 0xf9, 0x6e,
-	0xe8, 0xe2, 0xd2, 0x85, 0x3b, 0xa7, 0xcb, 0x40, 0x5f, 0xc3, 0x41, 0x73, 0xb9, 0x34, 0x58, 0xe6,
-	0xad, 0x3f, 0xf5, 0x3c, 0xea, 0xe3, 0x97, 0xa0, 0xf8, 0xd4, 0x73, 0x23, 0x4c, 0x93, 0xaa, 0x52,
-	0x4d, 0xad, 0xff, 0x77, 0x1c, 0xd3, 0x8f, 0x49, 0x92, 0x48, 0xb8, 0x24, 0x63, 0xe2, 0xa7, 0x20,
-	0x5f, 0x39, 0x41, 0x5c, 0x95, 0x8f, 0xaa, 0xfe, 0xe6, 0x55, 0x62, 0x45, 0x4a, 0xd2, 0x9f, 0x81,
-	0x2a, 0x24, 0xb0, 0x0e, 0xf9, 0x2b, 0x27, 0xd0, 0x72, 0xd5, 0x7c, 0x4d, 0xad, 0x23, 0x5e, 0x3a,
-	0x31, 0xec, 0x88, 0x4d, 0x58, 0x52, 0xff, 0x26, 0xc1, 0x9e, 0x6d, 0x77, 0x2c, 0xba, 0xe6, 0x55,
-	0xff, 0x83, 0x3c, 0x75, 0x9c, 0xb0, 0x3f, 0xbd, 0xa0, 0x91, 0x56, 0x85, 0xa4, 0x31, 0x7e, 0x00,
-	0xe0, 0xf9, 0x8b, 0xab, 0x69, 0x48, 0x2d, 0xba, 0xd6, 0x72, 0x55, 0xa9, 0x56, 0x21, 0x02, 0x82,
-	0x9f, 0x40, 0x39, 0xb8, 0x9c, 0x8d, 0xd6, 0x1e, 0xd5, 0xa0, 0x2a, 0xd5, 0xf6, 0x33, 0xc1, 0xf6,
-	0xe5, 0x8c, 0x9d, 0xca, 0x52, 0x84, 0x73, 0x58, 0xbb, 0xc5, 0x9c, 0xae, 0xc2, 0xc5, 0xd9, 0x82,
-	0xfa, 0x9a, 0x1a, 0x1d, 0x26, 0x20, 0xfa, 0x0b, 0x28, 0xdb, 0x76, 0x87, 0x09, 0xc3, 0x8f, 0xa0,
-	0x70, 0x4e, 0xd7, 0xcc, 0x3d, 0x36, 0xcc, 0xbf, 0x69, 0x5b, 0x51, 0x3a, 0x89, 0x28, 0xfa, 0x2f,
-	0x09, 0x64, 0x3e, 0x24, 0x9b, 0xc6, 0x59, 0x2e, 0xe8, 0x2a, 0xec, 0xce, 0xf9, 0x34, 0x3c, 0xc6,
-	0x3a, 0x54, 0xe2, 0xdf, 0x36, 0x75, 0x7c, 0x1a, 0x46, 0xf3, 0x28, 0x64, 0x03, 0xdb, 0x92, 0x28,
-	0x6f, 0x4b, 0x64, 0xfd, 0x43, 0xf7, 0x9c, 0xae, 0xc6, 0xa4, 0x17, 0xed, 0x48, 0x21, 0x69, 0xbc,
-	0xe1, 0x64, 0xe1, 0xba, 0x93, 0x41, 0xf0, 0xa9, 0xbd, 0x58, 0xd2, 0x9e, 0xeb, 0x68, 0xa5, 0xb8,
-	0x6f, 0x86, 0xec, 0xe8, 0xa4, 0xde, 0x80, 0x83, 0xad, 0x8b, 0x84, 0x1f, 0x42, 0x81, 0x5d, 0x25,
-	0x2d, 0x1f, 0x39, 0x76, 0xb8, 0x7d, 0xdf, 0x02, 0x12, 0xa5, 0xf5, 0x1f, 0x12, 0x28, 0x29, 0xc6,
-	0x24, 0x5f, 0x06, 0xd4, 0x5f, 0x09, 0xcb, 0xe7, 0x31, 0xcb, 0x79, 0xd3, 0x20, 0xf8, 0xec, 0xfa,
-	0xf3, 0xc4, 0xaa, 0x34, 0xc6, 0x1a, 0x94, 0x59, 0xb7, 0xb1, 0xbf, 0x4c, 0x66, 0xe1, 0xe1, 0x7d,
-	0x0c, 0xbc, 0xd5, 0xa4, 0x1d, 0x4d, 0xf8, 0x2a, 0x81, 0x6c, 0x35, 0xb2, 0xc5, 0xdf, 0x7a, 0x8d,
-	0xab, 0xa0, 0x9e, 0x37, 0x02, 0xc3, 0x5d, 0x85, 0x74, 0x15, 0x06, 0xc9, 0x30, 0x22, 0xb4, 0xa5,
-	0x3a, 0x7f, 0x4d, 0xb5, 0xa0, 0xac, 0x78, 0x0f, 0x65, 0xaf, 0xe1, 0x80, 0x0b, 0xe3, 0xeb, 0x79,
-	0x9c, 0x69, 0xdd, 0xfe, 0x42, 0x39, 0x4e, 0x52, 0x86, 0xfe, 0x53, 0x02, 0x68, 0x7a, 0xde, 0x92,
-	0xde, 0x3d, 0xdc, 0x5d, 0xd2, 0x75, 0xa8, 0x4c, 0x59, 0xa7, 0xf8, 0x82, 0x07, 0xc9, 0x57, 0xbc,
-	0x81, 0xe1, 0x3a, 0xfc, 0x23, 0xc6, 0x43, 0xbe, 0xf6, 0x78, 0xb7, 0x37, 0xe6, 0x76, 0xb5, 0xe4,
-	0x14, 0x0e, 0xb3, 0x81, 0xb8, 0x29, 0x75, 0x80, 0x69, 0x0a, 0x26, 0xdf, 0x3a, 0xe6, 0x6d, 0x32,
-	0x3a, 0x11, 0x58, 0xfa, 0x2b, 0x80, 0xbe, 0x1b, 0x2e, 0xce, 0xd6, 0xc9, 0x3b, 0x51, 0x74, 0x84,
-	0xe2, 0x54, 0x43, 0x4c, 0x89, 0xab, 0x63, 0x86, 0xfe, 0x5d, 0x02, 0x55, 0x80, 0xff, 0x68, 0xaa,
-	0x30, 0x5c, 0x6e, 0xe7, 0x87, 0xed, 0xc6, 0x1d, 0x6c, 0xbc, 0x3c, 0x85, 0xeb, 0x2f, 0xcf, 0xd1,
-	0x08, 0x64, 0xde, 0x18, 0x03, 0x94, 0xfa, 0xdd, 0xde, 0x47, 0x63, 0x84, 0xfe, 0xc2, 0x65, 0xc8,
-	0x4f, 0x0c, 0x1b, 0x49, 0x58, 0x86, 0x02, 0x31, 0x87, 0x03, 0x94, 0x63, 0x90, 0xd5, 0xb0, 0x51,
-	0x9e, 0xfd, 0xb0, 0xed, 0x0e, 0x2a, 0xe2, 0x0a, 0xc8, 0xfd, 0xc1, 0xa8, 0xdb, 0xee, 0x9a, 0x04,
-	0x95, 0xb0, 0x02, 0xc5, 0xe6, 0x70, 0xd8, 0x33, 0x51, 0xf9, 0xe8, 0x8b, 0x04, 0xaa, 0x20, 0x19,
-	0xab, 0x50, 0x66, 0x9d, 0xed, 0xa8, 0xf5, 0x1e, 0x28, 0xad, 0xee, 0xa8, 0x35, 0x36, 0x2c, 0x73,
-	0x84, 0x24, 0x76, 0xea, 0x69, 0x77, 0xd4, 0x19, 0xb7, 0x50, 0x8e, 0xb5, 0xe8, 0x9b, 0xef, 0xc6,
-	0xec, 0x10, 0x05, 0x8a, 0x6f, 0x9a, 0x13, 0xb3, 0x8f, 0x0a, 0x8c, 0x71, 0x32, 0x30, 0x2c, 0x93,
-	0xc4, 0x47, 0x5a, 0xe3, 0x96, 0x69, 0x0c, 0xfa, 0x6d, 0x54, 0x62, 0x19, 0xf6, 0x36, 0x9b, 0xef,
-	0x91, 0xcc, 0x0a, 0xec, 0x5e, 0xd3, 0xb0, 0x90, 0x82, 0xf7, 0x01, 0x4e, 0xcc, 0xc9, 0x90, 0x0c,
-	0xda, 0xdd, 0x9e, 0x89, 0xa0, 0x55, 0xf8, 0x90, 0xf3, 0x66, 0xb3, 0x52, 0xf4, 0x0f, 0xfa, 0xfc,
-	0x77, 0x00, 0x00, 0x00, 0xff, 0xff, 0x1f, 0x94, 0x75, 0x29, 0x50, 0x07, 0x00, 0x00,
+var fileDescriptor_creds_69d9d3ee77321fcd = []byte{
+	// 751 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x55, 0xdd, 0x6e, 0xd3, 0x4c,
+	0x10, 0xfd, 0x9c, 0x5f, 0x7b, 0x9c, 0xb6, 0xdb, 0xfd, 0x40, 0x58, 0x5c, 0xa0, 0xc8, 0x12, 0x52,
+	0xa8, 0xa0, 0x88, 0x00, 0x22, 0x77, 0x28, 0x71, 0x9d, 0x26, 0x72, 0x48, 0xa2, 0x75, 0x12, 0x7e,
+	0x6e, 0x50, 0xe2, 0x6c, 0x45, 0xd4, 0x34, 0xb6, 0x6c, 0xb7, 0x28, 0xef, 0xc0, 0x3d, 0x12, 0xe2,
+	0x81, 0xb8, 0xe3, 0x59, 0x78, 0x03, 0xb4, 0xb6, 0xd7, 0xde, 0xa4, 0x2d, 0x6d, 0xef, 0x32, 0x67,
+	0xce, 0xcc, 0x9e, 0x39, 0xb3, 0xde, 0x80, 0xea, 0xf8, 0x74, 0x1e, 0x1c, 0x7a, 0xbe, 0x1b, 0xba,
+	0xb8, 0x74, 0xe6, 0xce, 0xe9, 0x32, 0xd0, 0xd7, 0xb0, 0xd7, 0x5c, 0x2e, 0x0d, 0x96, 0x79, 0xef,
+	0x4f, 0x3d, 0x8f, 0xfa, 0xf8, 0x35, 0x28, 0x3e, 0xf5, 0xdc, 0x08, 0xd3, 0xa4, 0xaa, 0x54, 0x53,
+	0xeb, 0x0f, 0x0e, 0x63, 0xfa, 0x21, 0x49, 0x12, 0x09, 0x97, 0x64, 0x4c, 0xfc, 0x1c, 0xe4, 0x0b,
+	0x27, 0x88, 0xab, 0xf2, 0x51, 0xd5, 0xff, 0xbc, 0x4a, 0xac, 0x48, 0x49, 0xfa, 0x0b, 0x50, 0x85,
+	0x04, 0xd6, 0x21, 0x7f, 0xe1, 0x04, 0x5a, 0xae, 0x9a, 0xaf, 0xa9, 0x75, 0xc4, 0x4b, 0x27, 0x86,
+	0x1d, 0xb1, 0x09, 0x4b, 0xea, 0x3f, 0x24, 0xd8, 0xb1, 0xed, 0x8e, 0x45, 0xd7, 0xbc, 0xea, 0x21,
+	0xc8, 0x53, 0xc7, 0x09, 0xfb, 0xd3, 0x33, 0x1a, 0x69, 0x55, 0x48, 0x1a, 0xe3, 0x47, 0x00, 0x9e,
+	0xbf, 0xb8, 0x98, 0x86, 0xd4, 0xa2, 0x6b, 0x2d, 0x57, 0x95, 0x6a, 0x15, 0x22, 0x20, 0xf8, 0x19,
+	0x94, 0x83, 0xf3, 0xd9, 0x68, 0xed, 0x51, 0x0d, 0xaa, 0x52, 0x6d, 0x37, 0x13, 0x6c, 0x9f, 0xcf,
+	0xd8, 0xa9, 0x2c, 0x45, 0x38, 0x87, 0xb5, 0x5b, 0xcc, 0xe9, 0x2a, 0x5c, 0x9c, 0x2c, 0xa8, 0xaf,
+	0xa9, 0xd1, 0x61, 0x02, 0xa2, 0xbf, 0x82, 0xb2, 0x6d, 0x77, 0x98, 0x30, 0xfc, 0x04, 0x0a, 0xa7,
+	0x74, 0xcd, 0xdc, 0x63, 0xc3, 0xdc, 0x4f, 0xdb, 0x8a, 0xd2, 0x49, 0x44, 0xd1, 0xff, 0x48, 0x20,
+	0xf3, 0x21, 0xd9, 0x34, 0xce, 0x72, 0x41, 0x57, 0x61, 0x77, 0xce, 0xa7, 0xe1, 0x31, 0xd6, 0xa1,
+	0x12, 0xff, 0xb6, 0xa9, 0xe3, 0xd3, 0x30, 0x9a, 0x47, 0x21, 0x1b, 0xd8, 0x96, 0x44, 0x79, 0x5b,
+	0x22, 0xeb, 0x1f, 0xba, 0xa7, 0x74, 0x35, 0x26, 0xbd, 0x68, 0x47, 0x0a, 0x49, 0xe3, 0x0d, 0x27,
+	0x0b, 0x97, 0x9d, 0x0c, 0x82, 0x2f, 0xed, 0xc5, 0x92, 0xf6, 0x5c, 0x47, 0x2b, 0xc5, 0x7d, 0x33,
+	0xe4, 0x8e, 0x4e, 0xea, 0x0d, 0xd8, 0xdb, 0xba, 0x48, 0xf8, 0x31, 0x14, 0xd8, 0x55, 0xd2, 0xf2,
+	0x91, 0x63, 0xfb, 0xdb, 0xf7, 0x2d, 0x20, 0x51, 0x5a, 0xff, 0x25, 0x81, 0x92, 0x62, 0x4c, 0xf2,
+	0x79, 0x40, 0xfd, 0x95, 0xb0, 0x7c, 0x1e, 0xb3, 0x9c, 0x37, 0x0d, 0x82, 0xaf, 0xae, 0x3f, 0x4f,
+	0xac, 0x4a, 0x63, 0xac, 0x41, 0x99, 0x75, 0x1b, 0xfb, 0xcb, 0x64, 0x16, 0x1e, 0xde, 0xc6, 0xc0,
+	0x6b, 0x4d, 0xba, 0xa3, 0x09, 0xdf, 0x25, 0x90, 0xad, 0x46, 0xb6, 0xf8, 0x6b, 0xaf, 0x71, 0x15,
+	0xd4, 0xd3, 0x46, 0x60, 0xb8, 0xab, 0x90, 0xae, 0xc2, 0x20, 0x19, 0x46, 0x84, 0xb6, 0x54, 0xe7,
+	0x2f, 0xa9, 0x16, 0x94, 0x95, 0x6e, 0xa1, 0xec, 0x2d, 0xec, 0x71, 0x61, 0x7c, 0x3d, 0x4f, 0x33,
+	0xad, 0xdb, 0x5f, 0x28, 0xc7, 0x49, 0xca, 0xd0, 0x7f, 0x4b, 0x00, 0x4d, 0xcf, 0x5b, 0xd2, 0x9b,
+	0x87, 0xbb, 0x49, 0xba, 0x0e, 0x95, 0x29, 0xeb, 0x14, 0x5f, 0xf0, 0x20, 0xf9, 0x8a, 0x37, 0x30,
+	0x5c, 0x87, 0x7b, 0x62, 0x3c, 0xe4, 0x6b, 0x8f, 0x77, 0x7b, 0x65, 0x4e, 0xb4, 0xa4, 0x78, 0x0b,
+	0x4b, 0x8e, 0x61, 0x3f, 0x1b, 0x88, 0x9b, 0x52, 0x07, 0x98, 0xa6, 0x60, 0xf2, 0xad, 0x63, 0xde,
+	0x26, 0xa3, 0x13, 0x81, 0xa5, 0xbf, 0x01, 0xe8, 0xbb, 0xe1, 0xe2, 0x64, 0x9d, 0xbc, 0x13, 0x45,
+	0x47, 0x28, 0x4e, 0x35, 0xc4, 0x94, 0xb8, 0x3a, 0x66, 0xe8, 0x3f, 0x25, 0x50, 0x05, 0xf8, 0x9f,
+	0xa6, 0x0a, 0xc3, 0xe5, 0xee, 0xfc, 0xb0, 0x5d, 0xb9, 0x83, 0x8d, 0x97, 0xa7, 0x70, 0xf9, 0xe5,
+	0x39, 0x18, 0x81, 0xcc, 0x1b, 0x63, 0x80, 0x52, 0xbf, 0xdb, 0xfb, 0x6c, 0x8c, 0xd0, 0x7f, 0xb8,
+	0x0c, 0xf9, 0x89, 0x61, 0x23, 0x09, 0xcb, 0x50, 0x20, 0xe6, 0x70, 0x80, 0x72, 0x0c, 0xb2, 0x1a,
+	0x36, 0xca, 0xb3, 0x1f, 0xb6, 0xdd, 0x41, 0x45, 0x5c, 0x01, 0xb9, 0x3f, 0x18, 0x75, 0xdb, 0x5d,
+	0x93, 0xa0, 0x12, 0x56, 0xa0, 0xd8, 0x1c, 0x0e, 0x7b, 0x26, 0x2a, 0x1f, 0x7c, 0x93, 0x40, 0x15,
+	0x24, 0x63, 0x15, 0xca, 0xac, 0xb3, 0x1d, 0xb5, 0xde, 0x01, 0xa5, 0xd5, 0x1d, 0xb5, 0xc6, 0x86,
+	0x65, 0x8e, 0x90, 0xc4, 0x4e, 0x3d, 0xee, 0x8e, 0x3a, 0xe3, 0x16, 0xca, 0xb1, 0x16, 0x7d, 0xf3,
+	0xc3, 0x98, 0x1d, 0xa2, 0x40, 0xf1, 0x5d, 0x73, 0x62, 0xf6, 0x51, 0x81, 0x31, 0x8e, 0x06, 0x86,
+	0x65, 0x92, 0xf8, 0x48, 0x6b, 0xdc, 0x32, 0x8d, 0x41, 0xbf, 0x8d, 0x4a, 0x2c, 0xc3, 0xde, 0x66,
+	0xf3, 0x23, 0x92, 0x59, 0x81, 0xdd, 0x6b, 0x1a, 0x16, 0x52, 0xf0, 0x2e, 0xc0, 0x91, 0x39, 0x19,
+	0x92, 0x41, 0xbb, 0xdb, 0x33, 0x11, 0xb4, 0x0a, 0x9f, 0x72, 0xde, 0x6c, 0x56, 0x8a, 0xfe, 0x41,
+	0x5f, 0xfe, 0x0d, 0x00, 0x00, 0xff, 0xff, 0x0d, 0x0c, 0x04, 0x0b, 0x50, 0x07, 0x00, 0x00,
 }

--- a/models/pb/guideocelot.pb.go
+++ b/models/pb/guideocelot.pb.go
@@ -29,11 +29,11 @@ const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
 type BuildReq struct {
 	// acctRepo is the ocelot account to which the creds are uploaded and the repository you wish to operate on, in the form account/repo
-	AcctRepo string `protobuf:"bytes,1,opt,name=acctRepo" json:"acctRepo,omitempty"`
+	AcctRepo string `protobuf:"bytes,1,opt,name=acctRepo,proto3" json:"acctRepo,omitempty"`
 	// hash is the git hash to trigger.
-	Hash string `protobuf:"bytes,2,opt,name=hash" json:"hash,omitempty"`
+	Hash string `protobuf:"bytes,2,opt,name=hash,proto3" json:"hash,omitempty"`
 	// branch is the branch that corresponds to the git hash. if the git hash has never been built by ocelot, this field is required.
-	Branch               string   `protobuf:"bytes,3,opt,name=branch" json:"branch,omitempty"`
+	Branch               string   `protobuf:"bytes,3,opt,name=branch,proto3" json:"branch,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -86,13 +86,13 @@ func (m *BuildReq) GetBranch() string {
 
 type StatusQuery struct {
 	// hash is the git hash to get status of
-	Hash string `protobuf:"bytes,1,opt,name=hash" json:"hash,omitempty"`
+	Hash string `protobuf:"bytes,1,opt,name=hash,proto3" json:"hash,omitempty"`
 	// acctName is the corresponding account that the hash is attached to
-	AcctName string `protobuf:"bytes,2,opt,name=acctName" json:"acctName,omitempty"`
+	AcctName string `protobuf:"bytes,2,opt,name=acctName,proto3" json:"acctName,omitempty"`
 	// repoName is the corresponding repo name that the hash is attached to
-	RepoName string `protobuf:"bytes,3,opt,name=repoName" json:"repoName,omitempty"`
+	RepoName string `protobuf:"bytes,3,opt,name=repoName,proto3" json:"repoName,omitempty"`
 	// partialRepo is just the first n letters of repo
-	PartialRepo          string   `protobuf:"bytes,4,opt,name=partialRepo" json:"partialRepo,omitempty"`
+	PartialRepo          string   `protobuf:"bytes,4,opt,name=partialRepo,proto3" json:"partialRepo,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -155,9 +155,9 @@ func (m *StatusQuery) GetPartialRepo() string {
 // or you can query by build-id which in the case of log retrieval is only allowed if the build is completed.
 type BuildQuery struct {
 	// hash is the git hash that corresponds to a commit you wish to get information on
-	Hash string `protobuf:"bytes,1,opt,name=hash" json:"hash,omitempty"`
+	Hash string `protobuf:"bytes,1,opt,name=hash,proto3" json:"hash,omitempty"`
 	// build id is the build number given by ocelot that is associated with the commit
-	BuildId              int64    `protobuf:"varint,2,opt,name=buildId" json:"buildId,omitempty"`
+	BuildId              int64    `protobuf:"varint,2,opt,name=buildId,proto3" json:"buildId,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -202,7 +202,7 @@ func (m *BuildQuery) GetBuildId() int64 {
 }
 
 type Builds struct {
-	Builds               map[string]*BuildRuntimeInfo `protobuf:"bytes,1,rep,name=builds" json:"builds,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Builds               map[string]*BuildRuntimeInfo `protobuf:"bytes,1,rep,name=builds,proto3" json:"builds,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	XXX_NoUnkeyedLiteral struct{}                     `json:"-"`
 	XXX_unrecognized     []byte                       `json:"-"`
 	XXX_sizecache        int32                        `json:"-"`
@@ -241,18 +241,18 @@ func (m *Builds) GetBuilds() map[string]*BuildRuntimeInfo {
 
 type BuildRuntimeInfo struct {
 	// done says whether or not the build has completed
-	Done bool `protobuf:"varint,1,opt,name=done" json:"done,omitempty"`
+	Done bool `protobuf:"varint,1,opt,name=done,proto3" json:"done,omitempty"`
 	// ip is the ip of the werker node that is running the build
-	Ip string `protobuf:"bytes,2,opt,name=ip" json:"ip,omitempty"`
+	Ip string `protobuf:"bytes,2,opt,name=ip,proto3" json:"ip,omitempty"`
 	// grpcPort is the grpc port of the werker running the build
-	GrpcPort string `protobuf:"bytes,3,opt,name=grpcPort" json:"grpcPort,omitempty"`
+	GrpcPort string `protobuf:"bytes,3,opt,name=grpcPort,proto3" json:"grpcPort,omitempty"`
 	// hash is the git hash that is currently being built
-	Hash string `protobuf:"bytes,4,opt,name=hash" json:"hash,omitempty"`
+	Hash string `protobuf:"bytes,4,opt,name=hash,proto3" json:"hash,omitempty"`
 	// acctName is the vcs account that this build is assocated with
-	AcctName string `protobuf:"bytes,5,opt,name=acctName" json:"acctName,omitempty"`
+	AcctName string `protobuf:"bytes,5,opt,name=acctName,proto3" json:"acctName,omitempty"`
 	// repoName is the name of the git repository that is associated with this commit/build
-	RepoName             string   `protobuf:"bytes,6,opt,name=repoName" json:"repoName,omitempty"`
-	WsPort               string   `protobuf:"bytes,7,opt,name=wsPort" json:"wsPort,omitempty"`
+	RepoName             string   `protobuf:"bytes,6,opt,name=repoName,proto3" json:"repoName,omitempty"`
+	WsPort               string   `protobuf:"bytes,7,opt,name=wsPort,proto3" json:"wsPort,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -332,7 +332,7 @@ func (m *BuildRuntimeInfo) GetWsPort() string {
 }
 
 type LineResponse struct {
-	OutputLine           string   `protobuf:"bytes,1,opt,name=outputLine" json:"outputLine,omitempty"`
+	OutputLine           string   `protobuf:"bytes,1,opt,name=outputLine,proto3" json:"outputLine,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -371,11 +371,11 @@ func (m *LineResponse) GetOutputLine() string {
 
 type RepoAccount struct {
 	// repo is the VCS repository
-	Repo string `protobuf:"bytes,1,opt,name=repo" json:"repo,omitempty"`
+	Repo string `protobuf:"bytes,1,opt,name=repo,proto3" json:"repo,omitempty"`
 	// account is the VCS account
-	Account string `protobuf:"bytes,2,opt,name=account" json:"account,omitempty"`
+	Account string `protobuf:"bytes,2,opt,name=account,proto3" json:"account,omitempty"`
 	// limit is the number of summary records desired to be returned
-	Limit                int32    `protobuf:"varint,3,opt,name=limit" json:"limit,omitempty"`
+	Limit                int32    `protobuf:"varint,3,opt,name=limit,proto3" json:"limit,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -428,11 +428,11 @@ func (m *RepoAccount) GetLimit() int32 {
 
 type Status struct {
 	// buildSum is the BuildSummary object that correlates to the build in question
-	BuildSum *BuildSummary `protobuf:"bytes,1,opt,name=buildSum" json:"buildSum,omitempty"`
+	BuildSum *BuildSummary `protobuf:"bytes,1,opt,name=buildSum,proto3" json:"buildSum,omitempty"`
 	// stages is a all the StageStatus objects associated to the build in question
-	Stages []*StageStatus `protobuf:"bytes,2,rep,name=stages" json:"stages,omitempty"`
+	Stages []*StageStatus `protobuf:"bytes,2,rep,name=stages,proto3" json:"stages,omitempty"`
 	// isInConsul is a boolean that is used for determining if the build is "running" or not. if isInConsul=true, the build is still running
-	IsInConsul           bool     `protobuf:"varint,3,opt,name=isInConsul" json:"isInConsul,omitempty"`
+	IsInConsul           bool     `protobuf:"varint,3,opt,name=isInConsul,proto3" json:"isInConsul,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -485,17 +485,17 @@ func (m *Status) GetIsInConsul() bool {
 
 // StageStatus is the detailed information about a specific stage that was executed during the build
 type StageStatus struct {
-	StageStatus string `protobuf:"bytes,1,opt,name=StageStatus" json:"StageStatus,omitempty"`
+	StageStatus string `protobuf:"bytes,1,opt,name=StageStatus,proto3" json:"StageStatus,omitempty"`
 	// error is the error message; will either be populated by a stage not returning exit code 0 or an error handled in the code during the build
-	Error string `protobuf:"bytes,2,opt,name=error" json:"error,omitempty"`
+	Error string `protobuf:"bytes,2,opt,name=error,proto3" json:"error,omitempty"`
 	// status is whether or not hte build failed; 0 for pass; 1 for failed
-	Status int32 `protobuf:"varint,3,opt,name=status" json:"status,omitempty"`
+	Status int32 `protobuf:"varint,3,opt,name=status,proto3" json:"status,omitempty"`
 	// messages are some descriptions of each stage that are generated at runtime
-	Messages []string `protobuf:"bytes,4,rep,name=messages" json:"messages,omitempty"`
+	Messages []string `protobuf:"bytes,4,rep,name=messages,proto3" json:"messages,omitempty"`
 	// startTime is when this stage began execution
-	StartTime *timestamp.Timestamp `protobuf:"bytes,5,opt,name=startTime" json:"startTime,omitempty"`
+	StartTime *timestamp.Timestamp `protobuf:"bytes,5,opt,name=startTime,proto3" json:"startTime,omitempty"`
 	// stageDuration is how long the stage took to execute
-	StageDuration        float64  `protobuf:"fixed64,6,opt,name=stageDuration" json:"stageDuration,omitempty"`
+	StageDuration        float64  `protobuf:"fixed64,6,opt,name=stageDuration,proto3" json:"stageDuration,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -571,23 +571,23 @@ func (m *StageStatus) GetStageDuration() float64 {
 // it is a top level view of how a repository is "doing" in ocelot, ie build times, fail status..
 type BuildSummary struct {
 	// hash is the git commit hash that corresponds with this build information
-	Hash string `protobuf:"bytes,1,opt,name=hash" json:"hash,omitempty"`
+	Hash string `protobuf:"bytes,1,opt,name=hash,proto3" json:"hash,omitempty"`
 	// failed is whether or not the build failed
-	Failed bool `protobuf:"varint,2,opt,name=failed" json:"failed,omitempty"`
+	Failed bool `protobuf:"varint,2,opt,name=failed,proto3" json:"failed,omitempty"`
 	// buildTime is the datetime that the build was picked up off the queue by the werker
-	BuildTime *timestamp.Timestamp `protobuf:"bytes,3,opt,name=buildTime" json:"buildTime,omitempty"`
+	BuildTime *timestamp.Timestamp `protobuf:"bytes,3,opt,name=buildTime,proto3" json:"buildTime,omitempty"`
 	// account is the VCS account associated with the repository / commit
-	Account string `protobuf:"bytes,4,opt,name=account" json:"account,omitempty"`
+	Account string `protobuf:"bytes,4,opt,name=account,proto3" json:"account,omitempty"`
 	// buildDuration is the length of time the whole build took to execute
-	BuildDuration float64 `protobuf:"fixed64,5,opt,name=buildDuration" json:"buildDuration,omitempty"`
+	BuildDuration float64 `protobuf:"fixed64,5,opt,name=buildDuration,proto3" json:"buildDuration,omitempty"`
 	// repo is the repository associated with the account / commit
-	Repo string `protobuf:"bytes,6,opt,name=repo" json:"repo,omitempty"`
+	Repo string `protobuf:"bytes,6,opt,name=repo,proto3" json:"repo,omitempty"`
 	// branch is the branch associated with the commit when it was pushed
-	Branch string `protobuf:"bytes,7,opt,name=branch" json:"branch,omitempty"`
+	Branch string `protobuf:"bytes,7,opt,name=branch,proto3" json:"branch,omitempty"`
 	// buildId is the id given to the build entry by postgres. it is unique
-	BuildId int64 `protobuf:"varint,8,opt,name=buildId" json:"buildId,omitempty"`
+	BuildId int64 `protobuf:"varint,8,opt,name=buildId,proto3" json:"buildId,omitempty"`
 	// queueTime is the datetime that either a tracking component or the admin put the build request on the queue to be processed by the werker node
-	QueueTime            *timestamp.Timestamp `protobuf:"bytes,9,opt,name=queueTime" json:"queueTime,omitempty"`
+	QueueTime            *timestamp.Timestamp `protobuf:"bytes,9,opt,name=queueTime,proto3" json:"queueTime,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}             `json:"-"`
 	XXX_unrecognized     []byte               `json:"-"`
 	XXX_sizecache        int32                `json:"-"`
@@ -682,7 +682,7 @@ func (m *BuildSummary) GetQueueTime() *timestamp.Timestamp {
 
 // summaries is a wrapper for a list of BuildSummary objects because protobuf can be dumb
 type Summaries struct {
-	Sums                 []*BuildSummary `protobuf:"bytes,1,rep,name=sums" json:"sums,omitempty"`
+	Sums                 []*BuildSummary `protobuf:"bytes,1,rep,name=sums,proto3" json:"sums,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}        `json:"-"`
 	XXX_unrecognized     []byte          `json:"-"`
 	XXX_sizecache        int32           `json:"-"`
@@ -722,17 +722,17 @@ func (m *Summaries) GetSums() []*BuildSummary {
 // PollRequest encompasses all the data necessary to set up poll tracking in ocelot.
 type PollRequest struct {
 	// account is the VCS account
-	Account string `protobuf:"bytes,1,opt,name=account" json:"account,omitempty"`
+	Account string `protobuf:"bytes,1,opt,name=account,proto3" json:"account,omitempty"`
 	// repo is the VCS repository name
-	Repo string `protobuf:"bytes,2,opt,name=repo" json:"repo,omitempty"`
+	Repo string `protobuf:"bytes,2,opt,name=repo,proto3" json:"repo,omitempty"`
 	// cron is the cron string that will determine how often a check for changes should occur
-	Cron string `protobuf:"bytes,4,opt,name=cron" json:"cron,omitempty"`
+	Cron string `protobuf:"bytes,4,opt,name=cron,proto3" json:"cron,omitempty"`
 	// branches tells ocelot which branches should be checked for changes
-	Branches string `protobuf:"bytes,5,opt,name=branches" json:"branches,omitempty"`
+	Branches string `protobuf:"bytes,5,opt,name=branches,proto3" json:"branches,omitempty"`
 	// internal use only
-	LastCronTime *timestamp.Timestamp `protobuf:"bytes,6,opt,name=lastCronTime" json:"lastCronTime,omitempty"`
+	LastCronTime *timestamp.Timestamp `protobuf:"bytes,6,opt,name=lastCronTime,proto3" json:"lastCronTime,omitempty"`
 	// internal use only
-	LastHashes           map[string]string `protobuf:"bytes,7,rep,name=lastHashes" json:"lastHashes,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	LastHashes           map[string]string `protobuf:"bytes,7,rep,name=lastHashes,proto3" json:"lastHashes,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
 	XXX_unrecognized     []byte            `json:"-"`
 	XXX_sizecache        int32             `json:"-"`
@@ -806,7 +806,7 @@ func (m *PollRequest) GetLastHashes() map[string]string {
 
 // polls is a wrapper for a PollRequest list because protobuf can be dumb
 type Polls struct {
-	Polls                []*PollRequest `protobuf:"bytes,1,rep,name=polls" json:"polls,omitempty"`
+	Polls                []*PollRequest `protobuf:"bytes,1,rep,name=polls,proto3" json:"polls,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}       `json:"-"`
 	XXX_unrecognized     []byte         `json:"-"`
 	XXX_sizecache        int32          `json:"-"`
@@ -844,7 +844,7 @@ func (m *Polls) GetPolls() []*PollRequest {
 }
 
 type Exists struct {
-	Exists               bool     `protobuf:"varint,1,opt,name=exists" json:"exists,omitempty"`
+	Exists               bool     `protobuf:"varint,1,opt,name=exists,proto3" json:"exists,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -884,9 +884,9 @@ func (m *Exists) GetExists() bool {
 // Used in displaying all repos that are tracked by ocelot
 type AcctRepo struct {
 	// VCS Account
-	Account string `protobuf:"bytes,1,opt,name=account" json:"account,omitempty"`
+	Account string `protobuf:"bytes,1,opt,name=account,proto3" json:"account,omitempty"`
 	// VCS Repository
-	Repo                 string   `protobuf:"bytes,2,opt,name=repo" json:"repo,omitempty"`
+	Repo                 string   `protobuf:"bytes,2,opt,name=repo,proto3" json:"repo,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -932,7 +932,7 @@ func (m *AcctRepo) GetRepo() string {
 
 // AcctRepos is used in the response to /v1/tracked-repositories, it is an array of AcctRepo objects. have to wrap it cuz proto -_-
 type AcctRepos struct {
-	AcctRepos            []*AcctRepo `protobuf:"bytes,1,rep,name=acctRepos" json:"acctRepos,omitempty"`
+	AcctRepos            []*AcctRepo `protobuf:"bytes,1,rep,name=acctRepos,proto3" json:"acctRepos,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}    `json:"-"`
 	XXX_unrecognized     []byte      `json:"-"`
 	XXX_sizecache        int32       `json:"-"`

--- a/models/pb/guideocelot.pb.gw.go
+++ b/models/pb/guideocelot.pb.gw.go
@@ -88,7 +88,7 @@ func request_GuideOcelot_SetVCSCreds_0(ctx context.Context, marshaler runtime.Ma
 	var protoReq VCSCreds
 	var metadata runtime.ServerMetadata
 
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil {
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -101,7 +101,7 @@ func request_GuideOcelot_UpdateVCSCreds_0(ctx context.Context, marshaler runtime
 	var protoReq VCSCreds
 	var metadata runtime.ServerMetadata
 
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil {
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -143,7 +143,7 @@ func request_GuideOcelot_SetVCSPrivateKey_0(ctx context.Context, marshaler runti
 	var protoReq SSHKeyWrapper
 	var metadata runtime.ServerMetadata
 
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil {
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -231,7 +231,7 @@ func request_GuideOcelot_UpdateRepoCreds_0(ctx context.Context, marshaler runtim
 	var protoReq RepoCreds
 	var metadata runtime.ServerMetadata
 
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil {
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -319,7 +319,7 @@ func request_GuideOcelot_UpdateK8SCreds_0(ctx context.Context, marshaler runtime
 	var protoReq K8SCreds
 	var metadata runtime.ServerMetadata
 
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil {
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -361,7 +361,7 @@ func request_GuideOcelot_SetNotifyCreds_0(ctx context.Context, marshaler runtime
 	var protoReq NotifyCreds
 	var metadata runtime.ServerMetadata
 
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil {
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -429,7 +429,7 @@ func request_GuideOcelot_UpdateNotifyCreds_0(ctx context.Context, marshaler runt
 	var protoReq NotifyCreds
 	var metadata runtime.ServerMetadata
 
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil {
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -471,7 +471,7 @@ func request_GuideOcelot_UpdateSSHCreds_0(ctx context.Context, marshaler runtime
 	var protoReq SSHKeyWrapper
 	var metadata runtime.ServerMetadata
 
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil {
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -559,7 +559,7 @@ func request_GuideOcelot_SetSSHCreds_0(ctx context.Context, marshaler runtime.Ma
 	var protoReq SSHKeyWrapper
 	var metadata runtime.ServerMetadata
 
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil {
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -590,7 +590,7 @@ func request_GuideOcelot_SetRepoCreds_0(ctx context.Context, marshaler runtime.M
 	var protoReq RepoCreds
 	var metadata runtime.ServerMetadata
 
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil {
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -603,7 +603,7 @@ func request_GuideOcelot_SetK8SCreds_0(ctx context.Context, marshaler runtime.Ma
 	var protoReq K8SCreds
 	var metadata runtime.ServerMetadata
 
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil {
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -625,7 +625,7 @@ func request_GuideOcelot_SetAppleCreds_0(ctx context.Context, marshaler runtime.
 	var protoReq AppleCreds
 	var metadata runtime.ServerMetadata
 
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil {
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -693,7 +693,7 @@ func request_GuideOcelot_UpdateAppleCreds_0(ctx context.Context, marshaler runti
 	var protoReq AppleCreds
 	var metadata runtime.ServerMetadata
 
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil {
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -840,7 +840,7 @@ func request_GuideOcelot_WatchRepo_0(ctx context.Context, marshaler runtime.Mars
 	var protoReq RepoAccount
 	var metadata runtime.ServerMetadata
 
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil {
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -853,7 +853,7 @@ func request_GuideOcelot_BuildRepoAndHash_0(ctx context.Context, marshaler runti
 	var protoReq BuildReq
 	var metadata runtime.ServerMetadata
 
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil {
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -874,7 +874,7 @@ func request_GuideOcelot_PollRepo_0(ctx context.Context, marshaler runtime.Marsh
 	var protoReq PollRequest
 	var metadata runtime.ServerMetadata
 
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil {
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -992,14 +992,14 @@ func RegisterGuideOcelotHandlerFromEndpoint(ctx context.Context, mux *runtime.Se
 	defer func() {
 		if err != nil {
 			if cerr := conn.Close(); cerr != nil {
-				grpclog.Printf("Failed to close conn to %s: %v", endpoint, cerr)
+				grpclog.Infof("Failed to close conn to %s: %v", endpoint, cerr)
 			}
 			return
 		}
 		go func() {
 			<-ctx.Done()
 			if cerr := conn.Close(); cerr != nil {
-				grpclog.Printf("Failed to close conn to %s: %v", endpoint, cerr)
+				grpclog.Infof("Failed to close conn to %s: %v", endpoint, cerr)
 			}
 		}()
 	}()

--- a/models/pb/guideocelot.swagger.json
+++ b/models/pb/guideocelot.swagger.json
@@ -1134,6 +1134,28 @@
             "in": "path",
             "required": true,
             "type": "string"
+          },
+          {
+            "name": "cron",
+            "description": "cron is the cron string that will determine how often a check for changes should occur.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "branches",
+            "description": "branches tells ocelot which branches should be checked for changes.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "lastCronTime",
+            "description": "internal use only.",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
           }
         ],
         "tags": [
@@ -1535,7 +1557,7 @@
         },
         "identifier": {
           "type": "string",
-          "title": "identifier in K8s creds is currently irrelevant, as there can only be one per account"
+          "title": "identifier in K8s creds, typically the name of the cluster, as expected use case is one config per cluster"
         },
         "subType": {
           "$ref": "#/definitions/modelsSubCredType",

--- a/models/pb/vcshandler.pb.go
+++ b/models/pb/vcshandler.pb.go
@@ -20,9 +20,9 @@ var _ = math.Inf
 const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
 type BranchHistory struct {
-	Branch               string               `protobuf:"bytes,1,opt,name=branch" json:"branch,omitempty"`
-	Hash                 string               `protobuf:"bytes,2,opt,name=hash" json:"hash,omitempty"`
-	LastCommitTime       *timestamp.Timestamp `protobuf:"bytes,3,opt,name=lastCommitTime" json:"lastCommitTime,omitempty"`
+	Branch               string               `protobuf:"bytes,1,opt,name=branch,proto3" json:"branch,omitempty"`
+	Hash                 string               `protobuf:"bytes,2,opt,name=hash,proto3" json:"hash,omitempty"`
+	LastCommitTime       *timestamp.Timestamp `protobuf:"bytes,3,opt,name=lastCommitTime,proto3" json:"lastCommitTime,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}             `json:"-"`
 	XXX_unrecognized     []byte               `json:"-"`
 	XXX_sizecache        int32                `json:"-"`

--- a/models/pb/werkerserver.pb.go
+++ b/models/pb/werkerserver.pb.go
@@ -24,7 +24,7 @@ var _ = math.Inf
 const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
 type Request struct {
-	Hash                 string   `protobuf:"bytes,1,opt,name=hash" json:"hash,omitempty"`
+	Hash                 string   `protobuf:"bytes,1,opt,name=hash,proto3" json:"hash,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -62,7 +62,7 @@ func (m *Request) GetHash() string {
 }
 
 type Response struct {
-	OutputLine           string   `protobuf:"bytes,1,opt,name=outputLine" json:"outputLine,omitempty"`
+	OutputLine           string   `protobuf:"bytes,1,opt,name=outputLine,proto3" json:"outputLine,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`

--- a/models/slack/pb/slack.pb.go
+++ b/models/slack/pb/slack.pb.go
@@ -20,17 +20,17 @@ const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
 type WebhookMsg struct {
 	// required
-	Text string `protobuf:"bytes,1,opt,name=text" json:"text,omitempty"`
+	Text string `protobuf:"bytes,1,opt,name=text,proto3" json:"text,omitempty"`
 	// if not entered, will be default channel of url
-	Channel string `protobuf:"bytes,2,opt,name=channel" json:"channel,omitempty"`
+	Channel string `protobuf:"bytes,2,opt,name=channel,proto3" json:"channel,omitempty"`
 	// if not entered, will be user that created webhook
-	Username string `protobuf:"bytes,3,opt,name=username" json:"username,omitempty"`
+	Username string `protobuf:"bytes,3,opt,name=username,proto3" json:"username,omitempty"`
 	// obv not required
-	IconUrl string `protobuf:"bytes,4,opt,name=icon_url,json=iconUrl" json:"icon_url,omitempty"`
+	IconUrl string `protobuf:"bytes,4,opt,name=icon_url,json=iconUrl,proto3" json:"icon_url,omitempty"`
 	// obv not required
-	IconEmoji string `protobuf:"bytes,5,opt,name=icon_emoji,json=iconEmoji" json:"icon_emoji,omitempty"`
+	IconEmoji string `protobuf:"bytes,5,opt,name=icon_emoji,json=iconEmoji,proto3" json:"icon_emoji,omitempty"`
 	// if you wanna get fancy
-	Attachments          []*Attachment `protobuf:"bytes,6,rep,name=attachments" json:"attachments,omitempty"`
+	Attachments          []*Attachment `protobuf:"bytes,6,rep,name=attachments,proto3" json:"attachments,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
 	XXX_unrecognized     []byte        `json:"-"`
 	XXX_sizecache        int32         `json:"-"`
@@ -103,9 +103,9 @@ func (m *WebhookMsg) GetAttachments() []*Attachment {
 }
 
 type Field struct {
-	Title                string   `protobuf:"bytes,1,opt,name=title" json:"title,omitempty"`
-	Value                string   `protobuf:"bytes,2,opt,name=value" json:"value,omitempty"`
-	Short                bool     `protobuf:"varint,3,opt,name=short" json:"short,omitempty"`
+	Title                string   `protobuf:"bytes,1,opt,name=title,proto3" json:"title,omitempty"`
+	Value                string   `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
+	Short                bool     `protobuf:"varint,3,opt,name=short,proto3" json:"short,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -157,20 +157,20 @@ func (m *Field) GetShort() bool {
 }
 
 type Attachment struct {
-	Fallback             string   `protobuf:"bytes,1,opt,name=fallback" json:"fallback,omitempty"`
-	Color                string   `protobuf:"bytes,2,opt,name=color" json:"color,omitempty"`
-	Pretext              string   `protobuf:"bytes,3,opt,name=pretext" json:"pretext,omitempty"`
-	AuthorName           string   `protobuf:"bytes,4,opt,name=author_name,json=authorName" json:"author_name,omitempty"`
-	AuthorLink           string   `protobuf:"bytes,5,opt,name=author_link,json=authorLink" json:"author_link,omitempty"`
-	AuthorIcon           string   `protobuf:"bytes,6,opt,name=author_icon,json=authorIcon" json:"author_icon,omitempty"`
-	Title                string   `protobuf:"bytes,7,opt,name=title" json:"title,omitempty"`
-	TitleLink            string   `protobuf:"bytes,8,opt,name=title_link,json=titleLink" json:"title_link,omitempty"`
-	Text                 string   `protobuf:"bytes,9,opt,name=text" json:"text,omitempty"`
-	Fields               []*Field `protobuf:"bytes,10,rep,name=fields" json:"fields,omitempty"`
-	ImageUrl             string   `protobuf:"bytes,11,opt,name=image_url,json=imageUrl" json:"image_url,omitempty"`
-	ThumbUrl             string   `protobuf:"bytes,12,opt,name=thumb_url,json=thumbUrl" json:"thumb_url,omitempty"`
-	Footer               string   `protobuf:"bytes,13,opt,name=footer" json:"footer,omitempty"`
-	FooterIcon           string   `protobuf:"bytes,14,opt,name=footer_icon,json=footerIcon" json:"footer_icon,omitempty"`
+	Fallback             string   `protobuf:"bytes,1,opt,name=fallback,proto3" json:"fallback,omitempty"`
+	Color                string   `protobuf:"bytes,2,opt,name=color,proto3" json:"color,omitempty"`
+	Pretext              string   `protobuf:"bytes,3,opt,name=pretext,proto3" json:"pretext,omitempty"`
+	AuthorName           string   `protobuf:"bytes,4,opt,name=author_name,json=authorName,proto3" json:"author_name,omitempty"`
+	AuthorLink           string   `protobuf:"bytes,5,opt,name=author_link,json=authorLink,proto3" json:"author_link,omitempty"`
+	AuthorIcon           string   `protobuf:"bytes,6,opt,name=author_icon,json=authorIcon,proto3" json:"author_icon,omitempty"`
+	Title                string   `protobuf:"bytes,7,opt,name=title,proto3" json:"title,omitempty"`
+	TitleLink            string   `protobuf:"bytes,8,opt,name=title_link,json=titleLink,proto3" json:"title_link,omitempty"`
+	Text                 string   `protobuf:"bytes,9,opt,name=text,proto3" json:"text,omitempty"`
+	Fields               []*Field `protobuf:"bytes,10,rep,name=fields,proto3" json:"fields,omitempty"`
+	ImageUrl             string   `protobuf:"bytes,11,opt,name=image_url,json=imageUrl,proto3" json:"image_url,omitempty"`
+	ThumbUrl             string   `protobuf:"bytes,12,opt,name=thumb_url,json=thumbUrl,proto3" json:"thumb_url,omitempty"`
+	Footer               string   `protobuf:"bytes,13,opt,name=footer,proto3" json:"footer,omitempty"`
+	FooterIcon           string   `protobuf:"bytes,14,opt,name=footer_icon,json=footerIcon,proto3" json:"footer_icon,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`


### PR DESCRIPTION
(Still need to update the tests!)

Added k8s creds naming support in client

Multiple k8s creds supported in a temporary way, by stuffing multiple creds into a json string, and processing through the bash shell (which is required due to new usage of environment variable indirection, used to write configs)

Writes a config file to `~/.kube/<k8s cred name>`, with exception to the legacy `THERECANONLYBEONE`, which temporarily continues to take `~/.kube/config` for backwards compatibility.
(Users will need to specify `--kubeconfig`, `--context`, and `--namespace` in their `kubectl` calls)

--
Lastly, updating docker-compose files for for usage in development. (Not recommended bc they eat up significant time and disk space between iterations.) The largest improvement here is configuring werker to run in a container, which I think is convenient to have as an option.