### PR TITLE
fix ocelot kill hanging

### DIFF
--- a/build/basher/basher.go
+++ b/build/basher/basher.go
@@ -119,8 +119,8 @@ func (b *Basher) DownloadKubectl(werkerPort string) []string {
 //CDAndRunCmds will cd into the root directory of the codebase and execute commands passed in
 func (b *Basher) CDAndRunCmds(cmds []string, commitHash string) []string {
 	cdCmd := fmt.Sprintf("cd %s", b.CloneDir(commitHash))
-	build := append([]string{cdCmd}, cmds...)
-	buildAndDeploy := append([]string{"/bin/sh", "-c", strings.Join(build, " && ")})
+	bild := append([]string{cdCmd}, cmds...)
+	buildAndDeploy := append([]string{"/dev/init", "-s", "--", "/bin/sh", "-c", strings.Join(bild, " && ")})
 	return buildAndDeploy
 }
 

--- a/build/builder/docker/docker.go
+++ b/build/builder/docker/docker.go
@@ -113,12 +113,14 @@ func (d *Docker) Setup(ctx context.Context, logout chan []byte, dockerIdChan cha
 	}
 
 	//homeDirectory, _ := homedir.Expand("~/.ocelot")
+	init := true
 	//host config binds are mount points
 	hostConfig := &container.HostConfig{
 		//TODO: have it be overridable via env variable
 		Binds: []string{"/var/run/docker.sock:/var/run/docker.sock"},
 		//Binds: []string{ homeDirectory + ":/.ocelot", "/var/run/docker.sock:/var/run/docker.sock"},
 		NetworkMode: "host",
+		Init: &init,
 	}
 
 	resp, err := cli.ContainerCreate(ctx, containerConfig, hostConfig, nil, "")

--- a/build/builder/docker/testutil.go
+++ b/build/builder/docker/testutil.go
@@ -126,11 +126,13 @@ func CreateLivingDockerContainer(t *testing.T, ctx context.Context, imageName st
 		AttachStdin:  true,
 		Tty:          true,
 	}
+	init := true
 	hostConfig := &container.HostConfig{
 		//TODO: have it be overridable via env variable
 		Binds: []string{"/var/run/docker.sock:/var/run/docker.sock"},
 		//Binds: []string{ homeDirectory + ":/.ocelot", "/var/run/docker.sock:/var/run/docker.sock"},
 		NetworkMode: "host",
+		Init: &init,
 	}
 	resp, err := cli.ContainerCreate(ctx, containerConfig, hostConfig, nil, "")
 	if err != nil {

--- a/build/cleaner/docker.go
+++ b/build/cleaner/docker.go
@@ -18,7 +18,7 @@ func (d *DockerCleaner) Cleanup(ctx context.Context, id string, logout chan []by
 		return err
 	}
 
-	if err := cli.ContainerKill(ctx, id, "SIGKILL"); err != nil {
+	if err = cli.ContainerKill(ctx, id, "SIGKILL"); err != nil {
 		if err == context.Canceled && logout != nil {
 			logout <- []byte("//////////REDRUM////////REDRUM////////REDRUM/////////")
 		}

--- a/common/testutil/docker.go
+++ b/common/testutil/docker.go
@@ -20,7 +20,7 @@ import (
 func DockerCreateExec(t *testing.T, ctx context.Context, imageName string, ports []string, mounts ...string) (cleanup func(), err error) {
 	portsString := " -p " + strings.Join(ports, " -p ")
 	mountsStrings := " -v " + strings.Join(mounts, " -v ")
-	command := fmt.Sprintf("docker run --rm -d %s %s %s", portsString, mountsStrings, imageName)
+	command := fmt.Sprintf("docker run --rm --init -d %s %s %s", portsString, mountsStrings, imageName)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd := exec.CommandContext(ctx, "/bin/bash", "-c", command)
@@ -68,6 +68,7 @@ func DockerCreate(t *testing.T, ctx context.Context, imageName string, ports []s
 		Tty:          true,
 	}
 	binds := append([]string{"/var/run/docker.sock:/var/run/docker.sock"}, mounts...)
+	init := true
 	hostConfig := &container.HostConfig{
 		//TODO: have it be overridable via env variable
 		Binds:        binds,
@@ -75,6 +76,7 @@ func DockerCreate(t *testing.T, ctx context.Context, imageName string, ports []s
 		AutoRemove:   true,
 		//Binds: []string{ homeDirectory + ":/.ocelot", "/var/run/docker.sock:/var/run/docker.sock"},
 		NetworkMode: "host",
+		Init: &init,
 	}
 	resp, err := cli.ContainerCreate(ctx, containerConfig, hostConfig, nil, "")
 	if err != nil {


### PR DESCRIPTION
there was an issue with docker builders where if the kill is executed in the middle of a tty input session, cancelling the context would just make it last forever and never close out the build. this is a docker api limitation, as the cancelled context is handled by them. as a workaround, the `ocelot kill` command will now also call cleanup and tidy up the leftover strings. yes, it is double the effort, there is a fixme for later. 